### PR TITLE
fix: Eliminate Arc memory leaks in Owned* guards map/filter_map

### DIFF
--- a/mea/src/rwlock/owned_mapped_read_guard.rs
+++ b/mea/src/rwlock/owned_mapped_read_guard.rs
@@ -200,8 +200,10 @@ impl<T: ?Sized, U: ?Sized> OwnedMappedRwLockReadGuard<T, U> {
         let d = NonNull::from(f(unsafe { orig.d.as_ref() }));
         let orig = ManuallyDrop::new(orig);
 
-        // Safely extract the Arc from the guard
-        let lock = orig.lock.clone();
+        // SAFETY: The original guard is wrapped in `ManuallyDrop` and will not be dropped.
+        // This allows us to safely move the `Arc` out of it and transfer ownership to the new
+        // guard.
+        let lock = unsafe { std::ptr::read(&orig.lock) };
 
         OwnedMappedRwLockReadGuard::new(d, lock)
     }
@@ -287,8 +289,10 @@ impl<T: ?Sized, U: ?Sized> OwnedMappedRwLockReadGuard<T, U> {
                 let d = NonNull::from(d);
                 let orig = ManuallyDrop::new(orig);
 
-                // Safely extract the Arc from the guard
-                let lock = orig.lock.clone();
+                // SAFETY: The original guard is wrapped in `ManuallyDrop` and will not be dropped.
+                // This allows us to safely move the `Arc` out of it and transfer ownership to the
+                // new guard.
+                let lock = unsafe { std::ptr::read(&orig.lock) };
 
                 Ok(OwnedMappedRwLockReadGuard::new(d, lock))
             }


### PR DESCRIPTION
Fix Arc memory leaks in:
- OwnedRwLockWriteGuard::{map, filter_map}
- OwnedMappedRwLockWriteGuard::{map, filter_map}
- OwnedMappedRwLockReadGuard::{map, filter_map}

**Why?**

Using ManuallyDrop together with Arc::clone() leaves the original strong ref stranded in ManuallyDrop, effectively leaking one strong ref per call.

**Solution:**

Replace ManuallyDrop + clone with ManuallyDrop + std::ptr::read(&orig.lock) to move the Arc out and transfer ownership to the new guard.

**Files changed**

- mea/src/rwlock/owned_write_guard.rs
- mea/src/rwlock/owned_mapped_write_guard.rs
- mea/src/rwlock/owned_mapped_read_guard.rs
- mea/src/rwlock/test.rs

Closes: #63