### PR TITLE
feat(once): implement Once primitive

### DIFF
--- a/mea/src/lib.rs
+++ b/mea/src/lib.rs
@@ -96,6 +96,7 @@ mod tests {
     use crate::mpsc;
     use crate::mutex::Mutex;
     use crate::mutex::MutexGuard;
+    use crate::once::Once;
     use crate::once::OnceCell;
     use crate::oneshot;
     use crate::rwlock::RwLock;
@@ -112,6 +113,7 @@ mod tests {
         fn do_assert_send_and_sync<T: Send + Sync>() {}
         do_assert_send_and_sync::<Barrier>();
         do_assert_send_and_sync::<Condvar>();
+        do_assert_send_and_sync::<Once>();
         do_assert_send_and_sync::<OnceCell<u32>>();
         do_assert_send_and_sync::<Latch>();
         do_assert_send_and_sync::<Semaphore>();
@@ -145,6 +147,8 @@ mod tests {
         do_assert_unpin::<Barrier>();
         do_assert_unpin::<Condvar>();
         do_assert_unpin::<Latch>();
+        do_assert_unpin::<Once>();
+        do_assert_unpin::<OnceCell<u32>>();
         do_assert_unpin::<Semaphore>();
         do_assert_unpin::<ShutdownSend>();
         do_assert_unpin::<ShutdownRecv>();

--- a/mea/src/once/mod.rs
+++ b/mea/src/once/mod.rs
@@ -12,10 +12,185 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Asynchronous primitives for one-time initialization.
+//! Asynchronous primitives for one-time async coordination.
+//!
+//! The module currently provides:
+//!
+//! - [`Once`]: An async synchronization primitive that ensures a one-time asynchronous operation
+//!   runs at most once, even when called concurrently.
+//! - [`OnceCell`]: A cell that can be written to only once, storing a value produced
+//!   asynchronously.
+
+use std::fmt;
+use std::ops::AsyncFnOnce;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+
+use crate::semaphore::Semaphore;
 
 mod once_cell;
+
 pub use self::once_cell::OnceCell;
 
 #[cfg(test)]
 mod tests;
+
+/// A synchronization primitive which can be used to run a one-time async initialization.
+///
+/// Unlike [`std::sync::Once`], this type never blocks a thread. The provided closure must
+/// produce a future and the future is awaited inside the primitive. Coordination happens
+/// with asynchronous semaphores, which keeps the implementation runtime-agnostic.
+///
+/// This type also intentionally omits "poisoning" semantics. If an initialization future is
+/// cancelled or panics, the attempt is abandoned and other tasks may retry the operation.
+/// Encode partial-initialization detection in the future itself (e.g. return a `Result`)
+/// when needed.
+///
+/// This type can only be constructed with Once::new().
+///
+/// See the [module level documentation](crate::once) for additional context.
+///
+/// # Examples
+///
+/// ```
+/// # #[tokio::main]
+/// # async fn main() {
+/// use std::sync::atomic::AtomicUsize;
+/// use std::sync::atomic::Ordering;
+///
+/// use mea::once::Once;
+///
+/// static ONCE: Once = Once::new();
+/// static COUNTER: AtomicUsize = AtomicUsize::new(0);
+///
+/// let handle1 = tokio::spawn(async {
+///     ONCE.call_once(async || {
+///         COUNTER.fetch_add(1, Ordering::SeqCst);
+///     })
+///     .await;
+/// });
+///
+/// let handle2 = tokio::spawn(async {
+///     ONCE.call_once(async || {
+///         COUNTER.fetch_add(1, Ordering::SeqCst);
+///     })
+///     .await;
+/// });
+///
+/// handle1.await.unwrap();
+/// handle2.await.unwrap();
+///
+/// // The counter is incremented only once, even though two tasks called `call_once`.
+/// assert_eq!(COUNTER.load(Ordering::SeqCst), 1);
+/// # }
+/// ```
+///
+/// [`OnceCell`]: crate::once::OnceCell
+pub struct Once {
+    done: AtomicBool,
+    semaphore: Semaphore,
+}
+
+impl Default for Once {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for Once {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Once")
+            .field("done", &self.is_completed())
+            .finish()
+    }
+}
+
+impl Once {
+    /// Creates a new `Once` instance.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mea::once::Once;
+    ///
+    /// static ONCE: Once = Once::new();
+    /// ```
+    pub const fn new() -> Self {
+        Self {
+            done: AtomicBool::new(false),
+            semaphore: Semaphore::new(1),
+        }
+    }
+
+    /// Returns `true` if some `call_once` has completed successfully.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// use mea::once::Once;
+    ///
+    /// static ONCE: Once = Once::new();
+    ///
+    /// assert!(!ONCE.is_completed());
+    ///
+    /// ONCE.call_once(async || {}).await;
+    ///
+    /// assert!(ONCE.is_completed());
+    /// # }
+    /// ```
+    #[inline(always)]
+    pub fn is_completed(&self) -> bool {
+        self.done.load(Ordering::Acquire)
+    }
+
+    /// Calls the given async closure if this is the first time `call_once` has been called
+    /// on this `Once` instance.
+    ///
+    /// If another task is currently running the closure, this call will wait for that task
+    /// to complete.
+    ///
+    /// If the provided operation is cancelled, the initialization attempt is cancelled. If there
+    /// are other tasks waiting, one of them will start another attempt.
+    ///
+    /// Calling call_once recursively on the same Once from within the closure will deadlock,
+    /// because the closure holds the semaphore permit while trying to acquire it again.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// use mea::once::Once;
+    ///
+    /// static ONCE: Once = Once::new();
+    ///
+    /// ONCE.call_once(async || {
+    ///     println!("Do some one-time async thing.");
+    /// })
+    /// .await;
+    /// # }
+    /// ```
+    pub async fn call_once<F>(&self, f: F)
+    where
+        F: AsyncFnOnce() -> (),
+    {
+        if self.is_completed() {
+            return;
+        }
+
+        let _permit = self.semaphore.acquire(1).await;
+
+        if self.is_completed() {
+            // double-checked: another task completed the initialization while we waited.
+            return;
+        }
+
+        f().await;
+
+        // Use `store` with `Release` ordering to ensure that when loading it with `Acquire`
+        // ordering, the side effects of the closure are visible.
+        self.done.store(true, Ordering::Release);
+    }
+}

--- a/mea/src/once/tests.rs
+++ b/mea/src/once/tests.rs
@@ -14,13 +14,16 @@
 
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use tokio::sync::Mutex;
 
+use super::Once;
 use super::once_cell::OnceCell;
 use crate::latch::Latch;
+use crate::test_runtime;
 
 struct Foo {
     value: Arc<AtomicBool>,
@@ -199,4 +202,137 @@ async fn get_mut_or_try_init() {
     .await
     .unwrap();
     assert_eq!(v, 15);
+}
+
+#[tokio::test]
+async fn test_call_once_runs_only_once() {
+    static ONCE: Once = Once::new();
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    assert!(!ONCE.is_completed());
+
+    ONCE.call_once(async || {
+        COUNTER.fetch_add(1, Ordering::SeqCst);
+    })
+    .await;
+
+    assert!(ONCE.is_completed());
+    assert_eq!(COUNTER.load(Ordering::SeqCst), 1);
+
+    // Second call should not run the closure
+    ONCE.call_once(async || {
+        COUNTER.fetch_add(1, Ordering::SeqCst);
+    })
+    .await;
+
+    assert_eq!(COUNTER.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn test_once_multi_task() {
+    static ONCE: Once = Once::new();
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    test_runtime().block_on(async {
+        const N: usize = 100;
+
+        let latch = Arc::new(Latch::new(N as u32));
+        let mut handles = Vec::with_capacity(N);
+
+        for _ in 0..N {
+            let latch = latch.clone();
+            handles.push(tokio::spawn(async move {
+                ONCE.call_once(async || {
+                    COUNTER.fetch_add(1, Ordering::SeqCst);
+                })
+                .await;
+                latch.count_down();
+            }));
+        }
+
+        latch.wait().await;
+
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        // Only one task should have incremented the counter
+        assert_eq!(COUNTER.load(Ordering::SeqCst), 1);
+        assert!(ONCE.is_completed());
+    });
+}
+
+#[tokio::test]
+async fn test_once_cancelled() {
+    static ONCE: Once = Once::new();
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    let handle1 = tokio::spawn(async {
+        let fut = ONCE.call_once(async || {
+            tokio::time::sleep(Duration::from_millis(1000)).await;
+            COUNTER.fetch_add(1, Ordering::SeqCst);
+        });
+        let timeout = tokio::time::timeout(Duration::from_millis(1), fut).await;
+        assert!(timeout.is_err());
+    });
+
+    let handle2 = tokio::spawn(async {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        ONCE.call_once(async || {
+            COUNTER.fetch_add(10, Ordering::SeqCst);
+        })
+        .await;
+    });
+
+    handle1.await.unwrap();
+    handle2.await.unwrap();
+
+    // The second task should have run since the first was cancelled
+    assert_eq!(COUNTER.load(Ordering::SeqCst), 10);
+    assert!(ONCE.is_completed());
+}
+
+#[tokio::test]
+async fn test_once_debug() {
+    let once = Once::new();
+    let debug_str = format!("{:?}", once);
+    assert!(debug_str.contains("Once"));
+    assert!(debug_str.contains("done"));
+    assert!(debug_str.contains("false"));
+
+    once.call_once(async || {}).await;
+
+    let debug_str = format!("{:?}", once);
+    assert!(debug_str.contains("true"));
+}
+
+#[tokio::test]
+async fn test_once_default() {
+    let once = Once::default();
+    assert!(!once.is_completed());
+}
+
+#[tokio::test]
+async fn test_once_retry_after_panic() {
+    static ONCE: Once = Once::new();
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    let handle = tokio::spawn(async {
+        ONCE.call_once(async || {
+            COUNTER.fetch_add(1, Ordering::SeqCst);
+            panic!("boom");
+        })
+        .await;
+    });
+
+    let err = handle.await.expect_err("once init should panic");
+    assert!(err.is_panic());
+
+    ONCE.call_once(async || {
+        COUNTER.fetch_add(1, Ordering::SeqCst);
+    })
+    .await;
+
+    assert_eq!(COUNTER.load(Ordering::SeqCst), 2);
+    assert!(ONCE.is_completed());
 }


### PR DESCRIPTION
This PR implements a lock-free fast path and an async-mutex–based slow path for a Once primitive. The design is mainly inspired by Rust’s std::sync::Once and Go’s sync.Once  which I’m familiar with.

I didn’t create a dedicated once.rs file because it would conflict with the module name, so I placed the implementation directly inside mod.rs.
At the moment, wait() (similar to Rust’s Once::wait()) is not implemented yet. If we decide to add it, I think it would be better to use CountdownState instead of AtomicBool, so we can properly support wait() semantics.
The README.md has not been updated to reflect the new once module yet.

Please help me review the code and point out any mistakes. If you have any additional thoughts or suggestions, I’d greatly appreciate them.