### PR TITLE
feat: impl LazyCell

### DIFF
--- a/mea/src/once/lazy_cell.rs
+++ b/mea/src/once/lazy_cell.rs
@@ -1,0 +1,93 @@
+// Copyright 2024 tison <wander4096@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cell::UnsafeCell;
+use std::mem::ManuallyDrop;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+
+use crate::semaphore::Semaphore;
+
+union Data<T, F> {
+    value: ManuallyDrop<T>,
+    f: ManuallyDrop<F>,
+}
+
+///
+pub struct LazyCell<T, F> {
+    value_set: AtomicBool,
+    data: UnsafeCell<Data<T, F>>,
+    semaphore: Semaphore,
+}
+
+impl<T, F: AsyncFnOnce() -> T> LazyCell<T, F> {
+    ///
+    pub const fn new(f: F) -> LazyCell<T, F> {
+        LazyCell {
+            value_set: AtomicBool::new(false),
+            data: UnsafeCell::new(Data {
+                f: ManuallyDrop::new(f),
+            }),
+            semaphore: Semaphore::new(1),
+        }
+    }
+
+    /// Returns whether the internal value is set.
+    fn initialized(&self) -> bool {
+        self.value_set.load(Ordering::Acquire)
+    }
+
+    ///
+    pub fn get(&self) -> Option<&T> {
+        if self.initialized() {
+            Some(unsafe { &(*self.data.get()).value })
+        } else {
+            None
+        }
+    }
+
+    ///
+    pub async fn get_or_init(&self) -> &T {
+        if let Some(v) = self.get() {
+            return v;
+        }
+
+        let _permit = self.semaphore.acquire(1).await;
+
+        if let Some(v) = self.get() {
+            // double-checked: another task initialized the value
+            // while we were waiting for the permit
+            return v;
+        }
+
+        let data = unsafe { &mut *self.data.get() };
+        let f = unsafe { ManuallyDrop::take(&mut data.f) };
+        let value = f().await;
+        data.value = ManuallyDrop::new(value);
+        self.value_set.store(true, Ordering::Release);
+        unsafe { &*(*self.data.get()).value }
+    }
+}
+
+#[cfg(test)]
+#[tokio::test]
+async fn test_lazy_cell() {
+    let cell = LazyCell::new(|| async {
+        println!("initializing...");
+        42
+    });
+
+    let v1 = cell.get_or_init().await;
+    assert_eq!(*v1, 42);
+}

--- a/mea/src/once/mod.rs
+++ b/mea/src/once/mod.rs
@@ -21,10 +21,12 @@
 //! * [`OnceCell`]: A cell that can be written to at most once, storing a value produced
 //!   asynchronously.
 
+mod lazy_cell;
 #[allow(clippy::module_inception)]
 mod once;
 mod once_cell;
 
+pub use self::lazy_cell::LazyCell;
 pub use self::once::Once;
 pub use self::once_cell::OnceCell;
 


### PR DESCRIPTION
But since the init fn is async, we can't implement `Deref` like `std::sync::LazyCell`.

I wonder whether we really need LazyCell, but at least it allows users to define the initiator at the ctor, rather than always passing in later in `OnceCell::get_or_init(&self, f)`.