### PR TITLE
fix(broadcast): fix and test try_recv

### DIFF
--- a/mea/src/broadcast/tests.rs
+++ b/mea/src/broadcast/tests.rs
@@ -211,6 +211,18 @@ async fn test_try_recv_lagged() {
 }
 
 #[tokio::test]
+async fn test_try_recv_unwritten_slot_is_empty() {
+    let (tx, mut rx) = channel::<u64>(2);
+    drop(tx);
+
+    // Simulate tail advanced but slot not written yet
+    rx.shared.tail_cnt.store(1, Ordering::SeqCst);
+
+    assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
+    assert_eq!(rx.head, 0);
+}
+
+#[tokio::test]
 async fn test_multi_senders_concurrent() {
     let (tx, mut rx) = channel(100);
     let tx1 = tx.clone();


### PR DESCRIPTION
Following the comments in PR #90, change the logic in `broadcast::Receiver::try_recv` to be based on the wrapping version difference (`version_diff = head.wrapping_sub(slot.version)`). If the version matches and a message is present, return it normally. If the slot version is logically newer than head, re-read the latest tail and only report Lagged after confirming that the slot has indeed been overwritten.The slot version is initialized to 0, and combined with `msg == None` to indicate the `not ready yet` state.

Add tests to verify that when tail is advanced but the slot has not finished writing, `try_recv` returns Empty instead of incorrectly reporting Lagged.

By the way, while fixing the broadcast implementation, I realized that if a task is canceled while waiting (for example, due to `timeout(recv)`), its Waker may remain in the WaitSet. If the primitive does not get triggered for a long time (e.g. a long-idle broadcast channel, or a barrier that never reaches the final participant), these `zombie wakers` may never be cleaned up. In practice this is usually not a problem because events tend to be triggered frequently, but do we need to consider adjusting the `WaitSet` API for such extreme cases (for example, providing an `unregister method and calling it in `Drop`)?