### PR TITLE
feat: add fair-share admission control

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This project is licensed under [Apache License, Version 2.0](LICENSE).
 
 This crate collects runtime-agnostic synchronization primitives from spare parts:
 
-* **admission::FairShare** is written from scratch to bound global concurrency while balancing in-flight permits across contending keys.
+* **admission::FairShare** is written from scratch to bound global concurrency while balancing held permits across contending keys.
 * **Barrier** is inspired by `std::sync::Barrier` and `tokio::sync::Barrier`, with a different implementation based on the internal `WaitSet` primitive.
 * **Condvar** is inspired by `std::sync::Condvar` and `async_std::sync::Condvar`, with a different implementation based on the internal `Semaphore` primitive. Different from the async_std implementation, this condvar is fair.
 * **Latch** is inspired by [`latches`](https://github.com/mirromutth/latches), with a different implementation based on the internal `CountdownState` primitive. No `wait` or `watch` method is provided, since it can be easily implemented by [composing delay futures](https://docs.rs/fastimer/*/fastimer/fn.timeout.html). No sync variant is provided, since it can be easily implemented with block_on of any runtime.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ MEA is a runtime-agnostic library providing essential synchronization primitives
 
 ## Features
 
+* [**admission::FairShare**](https://docs.rs/mea/*/mea/admission/struct.FairShare.html): A work-conserving admission policy that fairly shares bounded concurrency across keys.
 * [**Barrier**](https://docs.rs/mea/*/mea/barrier/struct.Barrier.html): A synchronization primitive that enables tasks to wait until all participants arrive.
 * [**Condvar**](https://docs.rs/mea/*/mea/condvar/struct.Condvar.html): A condition variable that allows tasks to wait for a notification.
 * [**Latch**](https://docs.rs/mea/*/mea/latch/struct.Latch.html): A synchronization primitive that allows one or more tasks to wait until a set of operations completes.
@@ -70,6 +71,7 @@ This project is licensed under [Apache License, Version 2.0](LICENSE).
 
 This crate collects runtime-agnostic synchronization primitives from spare parts:
 
+* **admission::FairShare** is written from scratch to bound global concurrency while balancing in-flight permits across contending keys.
 * **Barrier** is inspired by `std::sync::Barrier` and `tokio::sync::Barrier`, with a different implementation based on the internal `WaitSet` primitive.
 * **Condvar** is inspired by `std::sync::Condvar` and `async_std::sync::Condvar`, with a different implementation based on the internal `Semaphore` primitive. Different from the async_std implementation, this condvar is fair.
 * **Latch** is inspired by [`latches`](https://github.com/mirromutth/latches), with a different implementation based on the internal `CountdownState` primitive. No `wait` or `watch` method is provided, since it can be easily implemented by [composing delay futures](https://docs.rs/fastimer/*/fastimer/fn.timeout.html). No sync variant is provided, since it can be easily implemented with block_on of any runtime.

--- a/mea/src/admission/fair_share.rs
+++ b/mea/src/admission/fair_share.rs
@@ -1,0 +1,559 @@
+// Copyright 2024 tison <wander4096@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::future::Future;
+use std::hash::BuildHasher;
+use std::hash::Hash;
+use std::hash::RandomState;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
+use std::task::Waker;
+
+use slab::Slab;
+
+use crate::internal::Mutex;
+
+/// A fixed-capacity admission controller that fairly shares permits across keys.
+///
+/// Each acquisition belongs to a key. When capacity becomes available,
+/// [`FairShare`] admits a queued acquisition for the key with the fewest
+/// permits currently in flight. Ties are resolved by queue order.
+///
+/// See the [module-level documentation](super) for details about the fairness
+/// guarantee.
+#[derive(Debug)]
+pub struct FairShare<K, S = RandomState>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    capacity: usize,
+    state: Mutex<State<K, S>>,
+}
+
+impl<K> FairShare<K, RandomState>
+where
+    K: Eq + Hash,
+{
+    /// Creates a fair-share admission controller with the given capacity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `capacity` is zero.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mea::admission::FairShare;
+    ///
+    /// let admission = FairShare::<String>::new(3);
+    /// assert_eq!(admission.capacity(), 3);
+    /// assert_eq!(admission.available_permits(), 3);
+    /// ```
+    pub fn new(capacity: usize) -> Self {
+        Self::with_hasher(capacity, RandomState::new())
+    }
+}
+
+impl<K, S> FairShare<K, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    /// Creates a fair-share admission controller with the given capacity and
+    /// hash builder.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `capacity` is zero.
+    pub fn with_hasher(capacity: usize, hash_builder: S) -> Self {
+        assert!(capacity > 0, "FairShare requires a non-zero capacity");
+        Self {
+            capacity,
+            state: Mutex::new(State::new(capacity, hash_builder)),
+        }
+    }
+
+    /// Returns the maximum number of permits that may be in flight.
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Returns the current number of permits available for immediate admission.
+    ///
+    /// A permit already assigned to a queued acquisition counts as in flight,
+    /// even if that acquisition has not yet been polled again.
+    pub fn available_permits(&self) -> usize {
+        self.state.lock().available
+    }
+
+    /// Returns the number of acquisitions waiting in the admission queue.
+    ///
+    /// Acquisitions that have been assigned a permit but have not yet been
+    /// polled again are not included.
+    pub fn queue_len(&self) -> usize {
+        self.state.lock().pending
+    }
+
+    /// Returns the number of permits currently in flight for `key`.
+    ///
+    /// A permit already assigned to a queued acquisition is included, even if
+    /// that acquisition has not yet been polled again.
+    pub fn in_flight(&self, key: &K) -> usize {
+        self.state.lock().in_flight(key)
+    }
+
+    /// Returns `true` when no permits are in flight and no acquisitions are pending.
+    pub fn is_idle(&self) -> bool {
+        let state = self.state.lock();
+        state.available == self.capacity
+            && state.pending == 0
+            && state.groups.is_empty()
+            && state.waiters.is_empty()
+    }
+
+    /// Attempts to acquire one permit for `key` without waiting.
+    ///
+    /// This method does not bypass queued acquisitions.
+    pub fn try_acquire(&self, key: K) -> Option<FairSharePermit<'_, K, S>> {
+        let key = Arc::new(key);
+        let admitted = self.state.lock().try_admit(key.clone());
+        admitted.then(|| FairSharePermit {
+            admission: self,
+            key,
+        })
+    }
+
+    /// Acquires one permit for `key`.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancelling this method loses the acquisition's place in the queue. If
+    /// a permit has already been assigned, cancellation releases it for another
+    /// queued acquisition.
+    pub async fn acquire(&self, key: K) -> FairSharePermit<'_, K, S> {
+        let key = Arc::new(key);
+        Acquire::new(self, key.clone()).await;
+        FairSharePermit {
+            admission: self,
+            key,
+        }
+    }
+
+    /// Attempts to acquire one owned permit for `key` without waiting.
+    ///
+    /// The admission controller must be wrapped in an [`Arc`] to call this
+    /// method.
+    pub fn try_acquire_owned(self: Arc<Self>, key: K) -> Option<OwnedFairSharePermit<K, S>> {
+        let key = Arc::new(key);
+        let admitted = self.state.lock().try_admit(key.clone());
+        admitted.then(|| OwnedFairSharePermit {
+            admission: self,
+            key,
+        })
+    }
+
+    /// Acquires one owned permit for `key`.
+    ///
+    /// The admission controller must be wrapped in an [`Arc`] to call this
+    /// method.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method has the same cancellation behavior as [`Self::acquire`].
+    pub async fn acquire_owned(self: Arc<Self>, key: K) -> OwnedFairSharePermit<K, S> {
+        let key = Arc::new(key);
+        Acquire::new(&self, key.clone()).await;
+        OwnedFairSharePermit {
+            admission: self,
+            key,
+        }
+    }
+
+    fn release(&self, key: &K) {
+        let mut wakers = Vec::new();
+        {
+            let mut state = self.state.lock();
+            state.release(key, self.capacity);
+            state.admit_waiters(&mut wakers);
+        }
+        wake_all(wakers);
+    }
+}
+
+#[derive(Debug)]
+struct State<K, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    available: usize,
+    pending: usize,
+    next_sequence: u64,
+    groups: HashMap<Arc<K>, GroupState, S>,
+    waiters: Slab<Waiter>,
+}
+
+impl<K, S> State<K, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    fn new(capacity: usize, hash_builder: S) -> Self {
+        Self {
+            available: capacity,
+            pending: 0,
+            next_sequence: 0,
+            groups: HashMap::with_hasher(hash_builder),
+            waiters: Slab::new(),
+        }
+    }
+
+    fn in_flight(&self, key: &K) -> usize {
+        self.groups.get(key).map_or(0, |group| group.in_flight)
+    }
+
+    fn try_admit(&mut self, key: Arc<K>) -> bool {
+        if self.available == 0 || self.pending != 0 {
+            return false;
+        }
+
+        self.available -= 1;
+        self.groups.entry(key).or_default().in_flight += 1;
+        true
+    }
+
+    fn enqueue(&mut self, key: Arc<K>, waker: &Waker) -> usize {
+        let sequence = self.next_sequence;
+        self.next_sequence = self
+            .next_sequence
+            .checked_add(1)
+            .expect("FairShare acquisition sequence overflowed u64::MAX");
+
+        let waiter = self.waiters.insert(Waiter {
+            sequence,
+            waker: Some(waker.clone()),
+            admitted: false,
+        });
+        self.groups.entry(key).or_default().queue.push_back(waiter);
+        self.pending += 1;
+        waiter
+    }
+
+    fn poll_waiter(&mut self, waiter: usize, waker: &Waker) -> Poll<()> {
+        let state = self
+            .waiters
+            .get_mut(waiter)
+            .expect("FairShare waiter is missing");
+
+        if state.admitted {
+            self.waiters.remove(waiter);
+            Poll::Ready(())
+        } else {
+            if state
+                .waker
+                .as_ref()
+                .is_none_or(|current| !current.will_wake(waker))
+            {
+                state.waker = Some(waker.clone());
+            }
+            Poll::Pending
+        }
+    }
+
+    fn cancel(&mut self, waiter_id: usize, key: &K, capacity: usize) {
+        let waiter = self.waiters.remove(waiter_id);
+        if waiter.admitted {
+            self.release(key, capacity);
+            return;
+        }
+
+        let remove_group = {
+            let group = self
+                .groups
+                .get_mut(key)
+                .expect("FairShare waiter group is missing");
+            let position = group
+                .queue
+                .iter()
+                .position(|candidate| *candidate == waiter_id)
+                .expect("FairShare waiter is missing from its group");
+            group.queue.remove(position);
+            group.in_flight == 0 && group.queue.is_empty()
+        };
+
+        self.pending -= 1;
+        if remove_group {
+            self.groups.remove(key);
+        }
+    }
+
+    fn admit_waiters(&mut self, wakers: &mut Vec<Waker>) {
+        while self.available > 0 && self.pending > 0 {
+            let key = self
+                .next_group()
+                .expect("FairShare has pending acquisitions without a group");
+            let waiter = self.groups[&key]
+                .queue
+                .front()
+                .copied()
+                .expect("FairShare pending group has no waiters");
+
+            {
+                let group = self
+                    .groups
+                    .get_mut(&key)
+                    .expect("FairShare pending group is missing");
+                let popped = group.queue.pop_front();
+                debug_assert_eq!(popped, Some(waiter));
+                group.in_flight += 1;
+            }
+
+            self.available -= 1;
+            self.pending -= 1;
+
+            let waiter = &mut self.waiters[waiter];
+            waiter.admitted = true;
+            if let Some(waker) = waiter.waker.take() {
+                wakers.push(waker);
+            }
+        }
+    }
+
+    fn next_group(&self) -> Option<Arc<K>> {
+        self.groups
+            .iter()
+            .filter_map(|(key, group)| {
+                let waiter = *group.queue.front()?;
+                let sequence = self.waiters[waiter].sequence;
+                Some((group.in_flight, sequence, key))
+            })
+            .min_by_key(|(in_flight, sequence, _)| (*in_flight, *sequence))
+            .map(|(_, _, key)| key.clone())
+    }
+
+    fn release(&mut self, key: &K, capacity: usize) {
+        let remove_group = {
+            let group = self
+                .groups
+                .get_mut(key)
+                .expect("FairShare released a permit for an unknown key");
+            debug_assert!(group.in_flight > 0);
+            group.in_flight -= 1;
+            group.in_flight == 0 && group.queue.is_empty()
+        };
+
+        if remove_group {
+            self.groups.remove(key);
+        }
+
+        self.available += 1;
+        debug_assert!(self.available <= capacity);
+    }
+}
+
+#[derive(Debug, Default)]
+struct GroupState {
+    in_flight: usize,
+    queue: VecDeque<usize>,
+}
+
+#[derive(Debug)]
+struct Waiter {
+    sequence: u64,
+    waker: Option<Waker>,
+    admitted: bool,
+}
+
+#[derive(Debug)]
+struct Acquire<'a, K, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    admission: &'a FairShare<K, S>,
+    key: Arc<K>,
+    waiter: Option<usize>,
+    completed: bool,
+}
+
+impl<'a, K, S> Acquire<'a, K, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    fn new(admission: &'a FairShare<K, S>, key: Arc<K>) -> Self {
+        Self {
+            admission,
+            key,
+            waiter: None,
+            completed: false,
+        }
+    }
+}
+
+impl<K, S> Drop for Acquire<'_, K, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    fn drop(&mut self) {
+        let Some(waiter) = self.waiter.take() else {
+            return;
+        };
+
+        let mut wakers = Vec::new();
+        {
+            let mut state = self.admission.state.lock();
+            state.cancel(waiter, &self.key, self.admission.capacity);
+            state.admit_waiters(&mut wakers);
+        }
+        wake_all(wakers);
+    }
+}
+
+impl<K, S> Future for Acquire<'_, K, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        if this.completed {
+            return Poll::Ready(());
+        }
+
+        if let Some(waiter) = this.waiter {
+            if this
+                .admission
+                .state
+                .lock()
+                .poll_waiter(waiter, cx.waker())
+                .is_ready()
+            {
+                this.waiter = None;
+                this.completed = true;
+                return Poll::Ready(());
+            }
+            return Poll::Pending;
+        }
+
+        let mut wakers = Vec::new();
+        let ready = {
+            let mut state = this.admission.state.lock();
+            if state.try_admit(this.key.clone()) {
+                this.completed = true;
+                return Poll::Ready(());
+            }
+
+            let waiter = state.enqueue(this.key.clone(), cx.waker());
+            this.waiter = Some(waiter);
+            state.admit_waiters(&mut wakers);
+            state.poll_waiter(waiter, cx.waker()).is_ready()
+        };
+        wake_all(wakers);
+
+        if ready {
+            this.waiter = None;
+            this.completed = true;
+            Poll::Ready(())
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+/// A borrowed permit acquired from a [`FairShare`] admission controller.
+///
+/// Dropping the permit releases its capacity to another queued acquisition.
+#[must_use = "permits are released immediately when dropped"]
+#[derive(Debug)]
+pub struct FairSharePermit<'a, K, S = RandomState>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    admission: &'a FairShare<K, S>,
+    key: Arc<K>,
+}
+
+impl<K, S> FairSharePermit<'_, K, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    /// Returns the key associated with this permit.
+    pub fn key(&self) -> &K {
+        &self.key
+    }
+}
+
+impl<K, S> Drop for FairSharePermit<'_, K, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    fn drop(&mut self) {
+        self.admission.release(&self.key);
+    }
+}
+
+/// An owned permit acquired from an [`Arc<FairShare>`].
+///
+/// Dropping the permit releases its capacity to another queued acquisition.
+///
+/// [`Arc<FairShare>`]: std::sync::Arc
+#[must_use = "permits are released immediately when dropped"]
+#[derive(Debug)]
+pub struct OwnedFairSharePermit<K, S = RandomState>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    admission: Arc<FairShare<K, S>>,
+    key: Arc<K>,
+}
+
+impl<K, S> OwnedFairSharePermit<K, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    /// Returns the key associated with this permit.
+    pub fn key(&self) -> &K {
+        &self.key
+    }
+}
+
+impl<K, S> Drop for OwnedFairSharePermit<K, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    fn drop(&mut self) {
+        self.admission.release(&self.key);
+    }
+}
+
+fn wake_all(wakers: Vec<Waker>) {
+    for waker in wakers {
+        waker.wake();
+    }
+}

--- a/mea/src/admission/fair_share.rs
+++ b/mea/src/admission/fair_share.rs
@@ -32,7 +32,7 @@ use crate::internal::Mutex;
 ///
 /// Each acquisition belongs to a key. When a permit becomes available,
 /// [`FairShare`] admits a queued acquisition for the key with the fewest
-/// permits currently in flight. Ties are resolved by queue order.
+/// permits currently held. Ties are resolved by queue order.
 ///
 /// See the [module-level documentation](super) for details about the fairness
 /// guarantee.
@@ -88,8 +88,8 @@ where
 
     /// Returns the current number of permits available for immediate admission.
     ///
-    /// A permit already assigned to a queued acquisition counts as in flight,
-    /// even if that acquisition has not yet been polled again.
+    /// A permit already assigned to a queued acquisition counts as held by its
+    /// key, even if that acquisition has not yet been polled again.
     pub fn available_permits(&self) -> usize {
         self.state.lock().available_permits
     }
@@ -199,7 +199,7 @@ where
         }
 
         self.available_permits -= 1;
-        self.groups.entry(key).or_default().in_flight += 1;
+        self.groups.entry(key).or_default().held_permits += 1;
         true
     }
 
@@ -259,7 +259,7 @@ where
                 .position(|candidate| *candidate == waiter_id)
                 .expect("FairShare waiter is missing from its group");
             group.queue.remove(position);
-            group.in_flight == 0 && group.queue.is_empty()
+            group.held_permits == 0 && group.queue.is_empty()
         };
 
         self.pending -= 1;
@@ -286,7 +286,7 @@ where
                     .expect("FairShare pending group is missing");
                 let popped = group.queue.pop_front();
                 debug_assert_eq!(popped, Some(waiter));
-                group.in_flight += 1;
+                group.held_permits += 1;
             }
 
             self.available_permits -= 1;
@@ -306,9 +306,9 @@ where
             .filter_map(|(key, group)| {
                 let waiter = *group.queue.front()?;
                 let sequence = self.waiters[waiter].sequence;
-                Some((group.in_flight, sequence, key))
+                Some((group.held_permits, sequence, key))
             })
-            .min_by_key(|(in_flight, sequence, _)| (*in_flight, *sequence))
+            .min_by_key(|(held_permits, sequence, _)| (*held_permits, *sequence))
             .map(|(_, _, key)| key.clone())
     }
 
@@ -318,9 +318,9 @@ where
                 .groups
                 .get_mut(key)
                 .expect("FairShare released a permit for an unknown key");
-            debug_assert!(group.in_flight > 0);
-            group.in_flight -= 1;
-            group.in_flight == 0 && group.queue.is_empty()
+            debug_assert!(group.held_permits > 0);
+            group.held_permits -= 1;
+            group.held_permits == 0 && group.queue.is_empty()
         };
 
         if remove_group {
@@ -334,7 +334,7 @@ where
 
 #[derive(Debug, Default)]
 struct GroupState {
-    in_flight: usize,
+    held_permits: usize,
     queue: VecDeque<usize>,
 }
 

--- a/mea/src/admission/fair_share.rs
+++ b/mea/src/admission/fair_share.rs
@@ -28,9 +28,9 @@ use slab::Slab;
 
 use crate::internal::Mutex;
 
-/// A fixed-capacity admission controller that fairly shares permits across keys.
+/// An admission controller that fairly shares a fixed number of permits across keys.
 ///
-/// Each acquisition belongs to a key. When capacity becomes available,
+/// Each acquisition belongs to a key. When a permit becomes available,
 /// [`FairShare`] admits a queued acquisition for the key with the fewest
 /// permits currently in flight. Ties are resolved by queue order.
 ///
@@ -42,7 +42,6 @@ where
     K: Eq + Hash,
     S: BuildHasher,
 {
-    capacity: usize,
     state: Mutex<State<K, S>>,
 }
 
@@ -50,11 +49,11 @@ impl<K> FairShare<K, RandomState>
 where
     K: Eq + Hash,
 {
-    /// Creates a fair-share admission controller with the given capacity.
+    /// Creates a fair-share admission controller with the given number of permits.
     ///
     /// # Panics
     ///
-    /// Panics if `capacity` is zero.
+    /// Panics if `permits` is zero.
     ///
     /// # Examples
     ///
@@ -62,11 +61,10 @@ where
     /// use mea::admission::FairShare;
     ///
     /// let admission = FairShare::<String>::new(3);
-    /// assert_eq!(admission.capacity(), 3);
     /// assert_eq!(admission.available_permits(), 3);
     /// ```
-    pub fn new(capacity: usize) -> Self {
-        Self::with_hasher(capacity, RandomState::new())
+    pub fn new(permits: usize) -> Self {
+        Self::with_hasher(permits, RandomState::new())
     }
 }
 
@@ -75,23 +73,17 @@ where
     K: Eq + Hash,
     S: BuildHasher,
 {
-    /// Creates a fair-share admission controller with the given capacity and
-    /// hash builder.
+    /// Creates a fair-share admission controller with the given number of
+    /// permits and hash builder.
     ///
     /// # Panics
     ///
-    /// Panics if `capacity` is zero.
-    pub fn with_hasher(capacity: usize, hash_builder: S) -> Self {
-        assert!(capacity > 0, "FairShare requires a non-zero capacity");
+    /// Panics if `permits` is zero.
+    pub fn with_hasher(permits: usize, hash_builder: S) -> Self {
+        assert!(permits > 0, "FairShare requires at least one permit");
         Self {
-            capacity,
-            state: Mutex::new(State::new(capacity, hash_builder)),
+            state: Mutex::new(State::new(permits, hash_builder)),
         }
-    }
-
-    /// Returns the maximum number of permits that may be in flight.
-    pub fn capacity(&self) -> usize {
-        self.capacity
     }
 
     /// Returns the current number of permits available for immediate admission.
@@ -99,32 +91,7 @@ where
     /// A permit already assigned to a queued acquisition counts as in flight,
     /// even if that acquisition has not yet been polled again.
     pub fn available_permits(&self) -> usize {
-        self.state.lock().available
-    }
-
-    /// Returns the number of acquisitions waiting in the admission queue.
-    ///
-    /// Acquisitions that have been assigned a permit but have not yet been
-    /// polled again are not included.
-    pub fn queue_len(&self) -> usize {
-        self.state.lock().pending
-    }
-
-    /// Returns the number of permits currently in flight for `key`.
-    ///
-    /// A permit already assigned to a queued acquisition is included, even if
-    /// that acquisition has not yet been polled again.
-    pub fn in_flight(&self, key: &K) -> usize {
-        self.state.lock().in_flight(key)
-    }
-
-    /// Returns `true` when no permits are in flight and no acquisitions are pending.
-    pub fn is_idle(&self) -> bool {
-        let state = self.state.lock();
-        state.available == self.capacity
-            && state.pending == 0
-            && state.groups.is_empty()
-            && state.waiters.is_empty()
+        self.state.lock().available_permits
     }
 
     /// Attempts to acquire one permit for `key` without waiting.
@@ -189,7 +156,7 @@ where
         let mut wakers = Vec::new();
         {
             let mut state = self.state.lock();
-            state.release(key, self.capacity);
+            state.release(key);
             state.admit_waiters(&mut wakers);
         }
         wake_all(wakers);
@@ -202,7 +169,8 @@ where
     K: Eq + Hash,
     S: BuildHasher,
 {
-    available: usize,
+    total_permits: usize,
+    available_permits: usize,
     pending: usize,
     next_sequence: u64,
     groups: HashMap<Arc<K>, GroupState, S>,
@@ -214,9 +182,10 @@ where
     K: Eq + Hash,
     S: BuildHasher,
 {
-    fn new(capacity: usize, hash_builder: S) -> Self {
+    fn new(permits: usize, hash_builder: S) -> Self {
         Self {
-            available: capacity,
+            total_permits: permits,
+            available_permits: permits,
             pending: 0,
             next_sequence: 0,
             groups: HashMap::with_hasher(hash_builder),
@@ -224,16 +193,12 @@ where
         }
     }
 
-    fn in_flight(&self, key: &K) -> usize {
-        self.groups.get(key).map_or(0, |group| group.in_flight)
-    }
-
     fn try_admit(&mut self, key: Arc<K>) -> bool {
-        if self.available == 0 || self.pending != 0 {
+        if self.available_permits == 0 || self.pending != 0 {
             return false;
         }
 
-        self.available -= 1;
+        self.available_permits -= 1;
         self.groups.entry(key).or_default().in_flight += 1;
         true
     }
@@ -276,10 +241,10 @@ where
         }
     }
 
-    fn cancel(&mut self, waiter_id: usize, key: &K, capacity: usize) {
+    fn cancel(&mut self, waiter_id: usize, key: &K) {
         let waiter = self.waiters.remove(waiter_id);
         if waiter.admitted {
-            self.release(key, capacity);
+            self.release(key);
             return;
         }
 
@@ -304,7 +269,7 @@ where
     }
 
     fn admit_waiters(&mut self, wakers: &mut Vec<Waker>) {
-        while self.available > 0 && self.pending > 0 {
+        while self.available_permits > 0 && self.pending > 0 {
             let key = self
                 .next_group()
                 .expect("FairShare has pending acquisitions without a group");
@@ -324,7 +289,7 @@ where
                 group.in_flight += 1;
             }
 
-            self.available -= 1;
+            self.available_permits -= 1;
             self.pending -= 1;
 
             let waiter = &mut self.waiters[waiter];
@@ -347,7 +312,7 @@ where
             .map(|(_, _, key)| key.clone())
     }
 
-    fn release(&mut self, key: &K, capacity: usize) {
+    fn release(&mut self, key: &K) {
         let remove_group = {
             let group = self
                 .groups
@@ -362,8 +327,8 @@ where
             self.groups.remove(key);
         }
 
-        self.available += 1;
-        debug_assert!(self.available <= capacity);
+        self.available_permits += 1;
+        debug_assert!(self.available_permits <= self.total_permits);
     }
 }
 
@@ -420,7 +385,7 @@ where
         let mut wakers = Vec::new();
         {
             let mut state = self.admission.state.lock();
-            state.cancel(waiter, &self.key, self.admission.capacity);
+            state.cancel(waiter, &self.key);
             state.admit_waiters(&mut wakers);
         }
         wake_all(wakers);
@@ -480,9 +445,14 @@ where
     }
 }
 
-/// A borrowed permit acquired from a [`FairShare`] admission controller.
+/// A permit from a [`FairShare`] admission controller.
 ///
-/// Dropping the permit releases its capacity to another queued acquisition.
+/// This type is created by the [`acquire`] and [`try_acquire`] methods on
+/// [`FairShare`]. It represents one admitted operation associated with a key.
+/// Dropping it returns the permit and may admit another queued acquisition.
+///
+/// [`acquire`]: FairShare::acquire
+/// [`try_acquire`]: FairShare::try_acquire
 #[must_use = "permits are released immediately when dropped"]
 #[derive(Debug)]
 pub struct FairSharePermit<'a, K, S = RandomState>
@@ -515,11 +485,16 @@ where
     }
 }
 
-/// An owned permit acquired from an [`Arc<FairShare>`].
+/// An owned permit from a [`FairShare`] admission controller.
 ///
-/// Dropping the permit releases its capacity to another queued acquisition.
+/// This type is created by the [`acquire_owned`] and [`try_acquire_owned`]
+/// methods on [`FairShare`]. Unlike [`FairSharePermit`], it owns an [`Arc`] to
+/// the admission controller and has no lifetime parameter. Dropping it returns
+/// the permit and may admit another queued acquisition.
 ///
-/// [`Arc<FairShare>`]: std::sync::Arc
+/// [`acquire_owned`]: FairShare::acquire_owned
+/// [`try_acquire_owned`]: FairShare::try_acquire_owned
+/// [`Arc`]: std::sync::Arc
 #[must_use = "permits are released immediately when dropped"]
 #[derive(Debug)]
 pub struct OwnedFairSharePermit<K, S = RandomState>

--- a/mea/src/admission/fair_share.rs
+++ b/mea/src/admission/fair_share.rs
@@ -94,6 +94,14 @@ where
         self.state.lock().available_permits
     }
 
+    /// Returns the number of acquisitions currently waiting for a permit.
+    ///
+    /// An acquisition is no longer counted once it has been assigned a permit,
+    /// even if its future has not yet been polled again.
+    pub fn num_waiters(&self) -> usize {
+        self.state.lock().num_waiters
+    }
+
     /// Attempts to acquire one permit for `key` without waiting.
     ///
     /// This method does not bypass queued acquisitions.
@@ -171,7 +179,7 @@ where
 {
     total_permits: usize,
     available_permits: usize,
-    pending: usize,
+    num_waiters: usize,
     next_sequence: u64,
     groups: HashMap<Arc<K>, GroupState, S>,
     waiters: Slab<Waiter>,
@@ -186,7 +194,7 @@ where
         Self {
             total_permits: permits,
             available_permits: permits,
-            pending: 0,
+            num_waiters: 0,
             next_sequence: 0,
             groups: HashMap::with_hasher(hash_builder),
             waiters: Slab::new(),
@@ -194,7 +202,7 @@ where
     }
 
     fn try_admit(&mut self, key: Arc<K>) -> bool {
-        if self.available_permits == 0 || self.pending != 0 {
+        if self.available_permits == 0 || self.num_waiters != 0 {
             return false;
         }
 
@@ -205,10 +213,7 @@ where
 
     fn enqueue(&mut self, key: Arc<K>, waker: &Waker) -> usize {
         let sequence = self.next_sequence;
-        self.next_sequence = self
-            .next_sequence
-            .checked_add(1)
-            .expect("FairShare acquisition sequence overflowed u64::MAX");
+        self.next_sequence += 1;
 
         let waiter = self.waiters.insert(Waiter {
             sequence,
@@ -216,7 +221,7 @@ where
             admitted: false,
         });
         self.groups.entry(key).or_default().queue.push_back(waiter);
-        self.pending += 1;
+        self.num_waiters += 1;
         waiter
     }
 
@@ -262,14 +267,14 @@ where
             group.held_permits == 0 && group.queue.is_empty()
         };
 
-        self.pending -= 1;
+        self.num_waiters -= 1;
         if remove_group {
             self.groups.remove(key);
         }
     }
 
     fn admit_waiters(&mut self, wakers: &mut Vec<Waker>) {
-        while self.available_permits > 0 && self.pending > 0 {
+        while self.available_permits > 0 && self.num_waiters > 0 {
             let key = self
                 .next_group()
                 .expect("FairShare has pending acquisitions without a group");
@@ -290,7 +295,7 @@ where
             }
 
             self.available_permits -= 1;
-            self.pending -= 1;
+            self.num_waiters -= 1;
 
             let waiter = &mut self.waiters[waiter];
             waiter.admitted = true;
@@ -494,7 +499,6 @@ where
 ///
 /// [`acquire_owned`]: FairShare::acquire_owned
 /// [`try_acquire_owned`]: FairShare::try_acquire_owned
-/// [`Arc`]: std::sync::Arc
 #[must_use = "permits are released immediately when dropped"]
 #[derive(Debug)]
 pub struct OwnedFairSharePermit<K, S = RandomState>

--- a/mea/src/admission/mod.rs
+++ b/mea/src/admission/mod.rs
@@ -17,7 +17,7 @@
 //! This module provides [`FairShare`], a work-conserving admission policy for
 //! workloads partitioned by key. It maintains a fixed number of permits and,
 //! when contended, admits work for the key with the fewest permits currently
-//! in flight. Ties are resolved by queue order.
+//! held. Ties are resolved by queue order.
 //!
 //! Fairness applies to the number of permits held by contending keys. It does
 //! not reserve permits for idle keys or account for differences in execution

--- a/mea/src/admission/mod.rs
+++ b/mea/src/admission/mod.rs
@@ -15,12 +15,12 @@
 //! Admission control policies for bounded asynchronous work.
 //!
 //! This module provides [`FairShare`], a work-conserving admission policy for
-//! workloads partitioned by key. It maintains a fixed capacity and, when
-//! contended, admits work for the key with the fewest permits currently in
-//! flight. Ties are resolved by queue order.
+//! workloads partitioned by key. It maintains a fixed number of permits and,
+//! when contended, admits work for the key with the fewest permits currently
+//! in flight. Ties are resolved by queue order.
 //!
 //! Fairness applies to the number of permits held by contending keys. It does
-//! not reserve capacity for idle keys or account for differences in execution
+//! not reserve permits for idle keys or account for differences in execution
 //! time or work cost.
 
 mod fair_share;

--- a/mea/src/admission/mod.rs
+++ b/mea/src/admission/mod.rs
@@ -1,0 +1,32 @@
+// Copyright 2024 tison <wander4096@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Admission control policies for bounded asynchronous work.
+//!
+//! This module provides [`FairShare`], a work-conserving admission policy for
+//! workloads partitioned by key. It maintains a fixed capacity and, when
+//! contended, admits work for the key with the fewest permits currently in
+//! flight. Ties are resolved by queue order.
+//!
+//! Fairness applies to the number of permits held by contending keys. It does
+//! not reserve capacity for idle keys or account for differences in execution
+//! time or work cost.
+
+mod fair_share;
+#[cfg(test)]
+mod tests;
+
+pub use fair_share::FairShare;
+pub use fair_share::FairSharePermit;
+pub use fair_share::OwnedFairSharePermit;

--- a/mea/src/admission/tests.rs
+++ b/mea/src/admission/tests.rs
@@ -34,39 +34,31 @@ where
 }
 
 #[test]
-#[should_panic(expected = "FairShare requires a non-zero capacity")]
-fn zero_capacity_panics() {
+#[should_panic(expected = "FairShare requires at least one permit")]
+fn zero_permits_panics() {
     FairShare::<usize>::new(0);
 }
 
 #[test]
-fn tracks_capacity_and_key_usage() {
+fn tracks_available_permits() {
     let admission = FairShare::new(2);
-    assert_eq!(admission.capacity(), 2);
     assert_eq!(admission.available_permits(), 2);
-    assert_eq!(admission.queue_len(), 0);
-    assert!(admission.is_idle());
 
     let permit_a0 = admission.try_acquire("a").unwrap();
     let permit_a1 = admission.try_acquire("a").unwrap();
     assert_eq!(permit_a0.key(), &"a");
     assert_eq!(admission.available_permits(), 0);
-    assert_eq!(admission.in_flight(&"a"), 2);
-    assert!(!admission.is_idle());
     assert!(admission.try_acquire("b").is_none());
 
     drop(permit_a0);
     assert_eq!(admission.available_permits(), 1);
-    assert_eq!(admission.in_flight(&"a"), 1);
 
     drop(permit_a1);
     assert_eq!(admission.available_permits(), 2);
-    assert_eq!(admission.in_flight(&"a"), 0);
-    assert!(admission.is_idle());
 }
 
 #[test]
-fn uses_spare_capacity_without_reservations() {
+fn uses_all_permits_without_reservations() {
     let admission = FairShare::new(3);
     let permits = [
         admission.try_acquire("a").unwrap(),
@@ -74,11 +66,10 @@ fn uses_spare_capacity_without_reservations() {
         admission.try_acquire("a").unwrap(),
     ];
 
-    assert_eq!(admission.in_flight(&"a"), 3);
     assert_eq!(admission.available_permits(), 0);
 
     drop(permits);
-    assert!(admission.is_idle());
+    assert_eq!(admission.available_permits(), 3);
 }
 
 #[test]
@@ -94,7 +85,6 @@ fn admits_the_key_with_the_smallest_share() {
     let acquire_b = admission.acquire("b");
     let mut acquire_b = pin!(acquire_b);
     assert!(poll_once(acquire_b.as_mut()).is_pending());
-    assert_eq!(admission.queue_len(), 2);
 
     drop(permit_a0);
     assert!(poll_once(acquire_a.as_mut()).is_pending());
@@ -113,7 +103,7 @@ fn admits_the_key_with_the_smallest_share() {
 }
 
 #[test]
-fn equalizes_capacity_across_contending_keys() {
+fn shares_permits_across_contending_keys() {
     let admission = FairShare::new(3);
     let mut held_by_a = vec![
         admission.try_acquire("a").unwrap(),
@@ -151,11 +141,12 @@ fn equalizes_capacity_across_contending_keys() {
         Poll::Pending => panic!("key a should receive the third released permit"),
     };
 
-    assert_eq!(admission.in_flight(&"a"), 1);
-    assert_eq!(admission.in_flight(&"b"), 1);
-    assert_eq!(admission.in_flight(&"c"), 1);
+    assert_eq!(permit_a.key(), &"a");
+    assert_eq!(permit_b.key(), &"b");
+    assert_eq!(permit_c.key(), &"c");
+    assert_eq!(admission.available_permits(), 0);
     drop((permit_a, permit_b, permit_c));
-    assert!(admission.is_idle());
+    assert_eq!(admission.available_permits(), 3);
 }
 
 #[test]
@@ -223,12 +214,10 @@ fn cancelling_a_pending_acquire_removes_it() {
         let acquire = admission.acquire(2usize);
         let mut acquire = pin!(acquire);
         assert!(poll_once(acquire.as_mut()).is_pending());
-        assert_eq!(admission.queue_len(), 1);
     }
 
-    assert_eq!(admission.queue_len(), 0);
     drop(held);
-    assert!(admission.is_idle());
+    assert_eq!(admission.available_permits(), 1);
 
     let permit = admission.try_acquire(3usize).unwrap();
     assert_eq!(permit.key(), &3);
@@ -246,13 +235,10 @@ fn cancelling_an_admitted_acquire_reassigns_its_permit() {
     assert!(poll_once(second.as_mut()).is_pending());
 
     drop(held);
-    assert_eq!(admission.in_flight(&"first"), 1);
-    assert_eq!(admission.queue_len(), 1);
+    assert_eq!(admission.available_permits(), 0);
 
     drop(first);
-    assert_eq!(admission.in_flight(&"first"), 0);
-    assert_eq!(admission.in_flight(&"second"), 1);
-    assert_eq!(admission.queue_len(), 0);
+    assert_eq!(admission.available_permits(), 0);
 
     let permit = match poll_once(second.as_mut()) {
         Poll::Ready(permit) => permit,
@@ -273,7 +259,6 @@ fn cancelling_within_a_key_preserves_its_queue() {
     assert!(poll_once(second.as_mut()).is_pending());
 
     drop(first);
-    assert_eq!(admission.queue_len(), 1);
 
     drop(held);
     let permit = match poll_once(second.as_mut()) {
@@ -299,7 +284,7 @@ fn owned_permit_keeps_the_admission_controller_alive() {
     let permit = admission
         .clone()
         .try_acquire_owned("tenant")
-        .expect("capacity should be available");
+        .expect("a permit should be available");
 
     drop(admission);
     assert_eq!(permit.key(), &"tenant");
@@ -318,7 +303,7 @@ fn acquire_futures_are_send() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn stress_test_preserves_capacity() {
+async fn stress_test_preserves_permit_limit() {
     let admission = Arc::new(FairShare::new(3));
     let active = Arc::new(AtomicUsize::new(0));
     let max_active = Arc::new(AtomicUsize::new(0));
@@ -346,6 +331,4 @@ async fn stress_test_preserves_capacity() {
     assert_eq!(active.load(Ordering::SeqCst), 0);
     assert!(max_active.load(Ordering::SeqCst) <= 3);
     assert_eq!(admission.available_permits(), 3);
-    assert_eq!(admission.queue_len(), 0);
-    assert!(admission.is_idle());
 }

--- a/mea/src/admission/tests.rs
+++ b/mea/src/admission/tests.rs
@@ -1,0 +1,351 @@
+// Copyright 2024 tison <wander4096@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::hash_map::DefaultHasher;
+use std::future::Future;
+use std::hash::BuildHasherDefault;
+use std::pin::Pin;
+use std::pin::pin;
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::task::Context;
+use std::task::Poll;
+use std::task::Waker;
+
+use super::FairShare;
+
+fn poll_once<F>(future: Pin<&mut F>) -> Poll<F::Output>
+where
+    F: Future,
+{
+    future.poll(&mut Context::from_waker(Waker::noop()))
+}
+
+#[test]
+#[should_panic(expected = "FairShare requires a non-zero capacity")]
+fn zero_capacity_panics() {
+    FairShare::<usize>::new(0);
+}
+
+#[test]
+fn tracks_capacity_and_key_usage() {
+    let admission = FairShare::new(2);
+    assert_eq!(admission.capacity(), 2);
+    assert_eq!(admission.available_permits(), 2);
+    assert_eq!(admission.queue_len(), 0);
+    assert!(admission.is_idle());
+
+    let permit_a0 = admission.try_acquire("a").unwrap();
+    let permit_a1 = admission.try_acquire("a").unwrap();
+    assert_eq!(permit_a0.key(), &"a");
+    assert_eq!(admission.available_permits(), 0);
+    assert_eq!(admission.in_flight(&"a"), 2);
+    assert!(!admission.is_idle());
+    assert!(admission.try_acquire("b").is_none());
+
+    drop(permit_a0);
+    assert_eq!(admission.available_permits(), 1);
+    assert_eq!(admission.in_flight(&"a"), 1);
+
+    drop(permit_a1);
+    assert_eq!(admission.available_permits(), 2);
+    assert_eq!(admission.in_flight(&"a"), 0);
+    assert!(admission.is_idle());
+}
+
+#[test]
+fn uses_spare_capacity_without_reservations() {
+    let admission = FairShare::new(3);
+    let permits = [
+        admission.try_acquire("a").unwrap(),
+        admission.try_acquire("a").unwrap(),
+        admission.try_acquire("a").unwrap(),
+    ];
+
+    assert_eq!(admission.in_flight(&"a"), 3);
+    assert_eq!(admission.available_permits(), 0);
+
+    drop(permits);
+    assert!(admission.is_idle());
+}
+
+#[test]
+fn admits_the_key_with_the_smallest_share() {
+    let admission = FairShare::new(2);
+    let permit_a0 = admission.try_acquire("a").unwrap();
+    let permit_a1 = admission.try_acquire("a").unwrap();
+
+    let acquire_a = admission.acquire("a");
+    let mut acquire_a = pin!(acquire_a);
+    assert!(poll_once(acquire_a.as_mut()).is_pending());
+
+    let acquire_b = admission.acquire("b");
+    let mut acquire_b = pin!(acquire_b);
+    assert!(poll_once(acquire_b.as_mut()).is_pending());
+    assert_eq!(admission.queue_len(), 2);
+
+    drop(permit_a0);
+    assert!(poll_once(acquire_a.as_mut()).is_pending());
+    let permit_b = match poll_once(acquire_b.as_mut()) {
+        Poll::Ready(permit) => permit,
+        Poll::Pending => panic!("key b should receive the released permit"),
+    };
+    assert_eq!(permit_b.key(), &"b");
+
+    drop(permit_a1);
+    let permit_a = match poll_once(acquire_a.as_mut()) {
+        Poll::Ready(permit) => permit,
+        Poll::Pending => panic!("key a should receive the next permit"),
+    };
+    assert_eq!(permit_a.key(), &"a");
+}
+
+#[test]
+fn equalizes_capacity_across_contending_keys() {
+    let admission = FairShare::new(3);
+    let mut held_by_a = vec![
+        admission.try_acquire("a").unwrap(),
+        admission.try_acquire("a").unwrap(),
+        admission.try_acquire("a").unwrap(),
+    ];
+
+    let acquire_a = admission.acquire("a");
+    let mut acquire_a = pin!(acquire_a);
+    assert!(poll_once(acquire_a.as_mut()).is_pending());
+
+    let acquire_b = admission.acquire("b");
+    let mut acquire_b = pin!(acquire_b);
+    assert!(poll_once(acquire_b.as_mut()).is_pending());
+
+    let acquire_c = admission.acquire("c");
+    let mut acquire_c = pin!(acquire_c);
+    assert!(poll_once(acquire_c.as_mut()).is_pending());
+
+    drop(held_by_a.pop().unwrap());
+    let permit_b = match poll_once(acquire_b.as_mut()) {
+        Poll::Ready(permit) => permit,
+        Poll::Pending => panic!("key b should receive the first released permit"),
+    };
+
+    drop(held_by_a.pop().unwrap());
+    let permit_c = match poll_once(acquire_c.as_mut()) {
+        Poll::Ready(permit) => permit,
+        Poll::Pending => panic!("key c should receive the second released permit"),
+    };
+
+    drop(held_by_a.pop().unwrap());
+    let permit_a = match poll_once(acquire_a.as_mut()) {
+        Poll::Ready(permit) => permit,
+        Poll::Pending => panic!("key a should receive the third released permit"),
+    };
+
+    assert_eq!(admission.in_flight(&"a"), 1);
+    assert_eq!(admission.in_flight(&"b"), 1);
+    assert_eq!(admission.in_flight(&"c"), 1);
+    drop((permit_a, permit_b, permit_c));
+    assert!(admission.is_idle());
+}
+
+#[test]
+fn breaks_equal_share_ties_by_queue_order() {
+    let admission = FairShare::new(1);
+    let held = admission.try_acquire("held").unwrap();
+
+    let acquire_b = admission.acquire("b");
+    let mut acquire_b = pin!(acquire_b);
+    assert!(poll_once(acquire_b.as_mut()).is_pending());
+
+    let acquire_a = admission.acquire("a");
+    let mut acquire_a = pin!(acquire_a);
+    assert!(poll_once(acquire_a.as_mut()).is_pending());
+
+    drop(held);
+    let permit_b = match poll_once(acquire_b.as_mut()) {
+        Poll::Ready(permit) => permit,
+        Poll::Pending => panic!("the first queued acquisition should win an equal-share tie"),
+    };
+    assert!(poll_once(acquire_a.as_mut()).is_pending());
+
+    drop(permit_b);
+    let permit_a = match poll_once(acquire_a.as_mut()) {
+        Poll::Ready(permit) => permit,
+        Poll::Pending => panic!("the second queued acquisition should be admitted next"),
+    };
+    assert_eq!(permit_a.key(), &"a");
+}
+
+#[test]
+fn preserves_queue_order_within_a_key() {
+    let admission = FairShare::new(1);
+    let held = admission.try_acquire(7usize).unwrap();
+
+    let first = admission.acquire(7usize);
+    let mut first = pin!(first);
+    assert!(poll_once(first.as_mut()).is_pending());
+
+    let second = admission.acquire(7usize);
+    let mut second = pin!(second);
+    assert!(poll_once(second.as_mut()).is_pending());
+
+    drop(held);
+    let first_permit = match poll_once(first.as_mut()) {
+        Poll::Ready(permit) => permit,
+        Poll::Pending => panic!("the first acquisition should be admitted first"),
+    };
+    assert!(poll_once(second.as_mut()).is_pending());
+
+    drop(first_permit);
+    let second_permit = match poll_once(second.as_mut()) {
+        Poll::Ready(permit) => permit,
+        Poll::Pending => panic!("the second acquisition should be admitted second"),
+    };
+    assert_eq!(second_permit.key(), &7);
+}
+
+#[test]
+fn cancelling_a_pending_acquire_removes_it() {
+    let admission = FairShare::new(1);
+    let held = admission.try_acquire(1usize).unwrap();
+
+    {
+        let acquire = admission.acquire(2usize);
+        let mut acquire = pin!(acquire);
+        assert!(poll_once(acquire.as_mut()).is_pending());
+        assert_eq!(admission.queue_len(), 1);
+    }
+
+    assert_eq!(admission.queue_len(), 0);
+    drop(held);
+    assert!(admission.is_idle());
+
+    let permit = admission.try_acquire(3usize).unwrap();
+    assert_eq!(permit.key(), &3);
+}
+
+#[test]
+fn cancelling_an_admitted_acquire_reassigns_its_permit() {
+    let admission = FairShare::new(1);
+    let held = admission.try_acquire("held").unwrap();
+
+    let mut first = Box::pin(admission.acquire("first"));
+    assert!(poll_once(first.as_mut()).is_pending());
+
+    let mut second = Box::pin(admission.acquire("second"));
+    assert!(poll_once(second.as_mut()).is_pending());
+
+    drop(held);
+    assert_eq!(admission.in_flight(&"first"), 1);
+    assert_eq!(admission.queue_len(), 1);
+
+    drop(first);
+    assert_eq!(admission.in_flight(&"first"), 0);
+    assert_eq!(admission.in_flight(&"second"), 1);
+    assert_eq!(admission.queue_len(), 0);
+
+    let permit = match poll_once(second.as_mut()) {
+        Poll::Ready(permit) => permit,
+        Poll::Pending => panic!("cancellation should reassign the granted permit"),
+    };
+    assert_eq!(permit.key(), &"second");
+}
+
+#[test]
+fn cancelling_within_a_key_preserves_its_queue() {
+    let admission = FairShare::new(1);
+    let held = admission.try_acquire("held").unwrap();
+
+    let mut first = Box::pin(admission.acquire("tenant"));
+    assert!(poll_once(first.as_mut()).is_pending());
+
+    let mut second = Box::pin(admission.acquire("tenant"));
+    assert!(poll_once(second.as_mut()).is_pending());
+
+    drop(first);
+    assert_eq!(admission.queue_len(), 1);
+
+    drop(held);
+    let permit = match poll_once(second.as_mut()) {
+        Poll::Ready(permit) => permit,
+        Poll::Pending => panic!("cancelling one acquisition must not detach the next"),
+    };
+    assert_eq!(permit.key(), &"tenant");
+}
+
+#[test]
+fn supports_a_custom_hash_builder() {
+    let admission = FairShare::<String, BuildHasherDefault<DefaultHasher>>::with_hasher(
+        1,
+        BuildHasherDefault::default(),
+    );
+    let permit = admission.try_acquire("tenant".to_owned()).unwrap();
+    assert_eq!(permit.key(), "tenant");
+}
+
+#[test]
+fn owned_permit_keeps_the_admission_controller_alive() {
+    let admission = Arc::new(FairShare::new(1));
+    let permit = admission
+        .clone()
+        .try_acquire_owned("tenant")
+        .expect("capacity should be available");
+
+    drop(admission);
+    assert_eq!(permit.key(), &"tenant");
+    drop(permit);
+}
+
+#[test]
+fn acquire_futures_are_send() {
+    fn assert_send<T: Send>(_: T) {}
+
+    let admission = FairShare::<String>::new(1);
+    assert_send(admission.acquire("tenant".to_owned()));
+
+    let admission = Arc::new(FairShare::<String>::new(1));
+    assert_send(admission.acquire_owned("tenant".to_owned()));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stress_test_preserves_capacity() {
+    let admission = Arc::new(FairShare::new(3));
+    let active = Arc::new(AtomicUsize::new(0));
+    let max_active = Arc::new(AtomicUsize::new(0));
+    let mut handles = Vec::new();
+
+    for key in 0..5usize {
+        for _ in 0..32usize {
+            let admission = admission.clone();
+            let active = active.clone();
+            let max_active = max_active.clone();
+            handles.push(tokio::spawn(async move {
+                let _permit = admission.acquire_owned(key).await;
+                let now = active.fetch_add(1, Ordering::SeqCst) + 1;
+                max_active.fetch_max(now, Ordering::SeqCst);
+                tokio::task::yield_now().await;
+                active.fetch_sub(1, Ordering::SeqCst);
+            }));
+        }
+    }
+
+    for handle in handles {
+        handle.await.unwrap();
+    }
+
+    assert_eq!(active.load(Ordering::SeqCst), 0);
+    assert!(max_active.load(Ordering::SeqCst) <= 3);
+    assert_eq!(admission.available_permits(), 3);
+    assert_eq!(admission.queue_len(), 0);
+    assert!(admission.is_idle());
+}

--- a/mea/src/lib.rs
+++ b/mea/src/lib.rs
@@ -21,6 +21,8 @@
 //!
 //! # Features
 //!
+//! * [`admission::FairShare`]: A work-conserving admission policy that fairly shares bounded
+//!   concurrency across keys
 //! * [`Barrier`]: A synchronization point where multiple tasks can wait until all participants
 //!   arrive
 //! * [`Condvar`]: A condition variable that allows tasks to wait for a notification
@@ -72,6 +74,7 @@
 
 mod internal;
 
+pub mod admission;
 pub mod atomicbox;
 pub mod barrier;
 pub mod broadcast;
@@ -98,6 +101,9 @@ fn test_runtime() -> &'static tokio::runtime::Runtime {
 
 #[cfg(test)]
 mod tests {
+    use crate::admission::FairShare;
+    use crate::admission::FairSharePermit;
+    use crate::admission::OwnedFairSharePermit;
     use crate::barrier::Barrier;
     use crate::broadcast;
     use crate::condvar::Condvar;
@@ -123,6 +129,9 @@ mod tests {
     #[test]
     fn assert_send_and_sync() {
         fn do_assert_send_and_sync<T: Send + Sync>() {}
+        do_assert_send_and_sync::<FairShare<String>>();
+        do_assert_send_and_sync::<FairSharePermit<'_, String>>();
+        do_assert_send_and_sync::<OwnedFairSharePermit<String>>();
         do_assert_send_and_sync::<Barrier>();
         do_assert_send_and_sync::<Condvar>();
         do_assert_send_and_sync::<Once>();
@@ -163,6 +172,9 @@ mod tests {
     #[test]
     fn assert_unpin() {
         fn do_assert_unpin<T: Unpin>() {}
+        do_assert_unpin::<FairShare<String>>();
+        do_assert_unpin::<FairSharePermit<'_, String>>();
+        do_assert_unpin::<OwnedFairSharePermit<String>>();
         do_assert_unpin::<Barrier>();
         do_assert_unpin::<Condvar>();
         do_assert_unpin::<Latch>();


### PR DESCRIPTION
## Summary

- introduce `mea::admission` as the problem-domain module and `FairShare` as its concrete work-conserving policy
- bound global concurrency while selecting the queued key with the fewest held permits, using queue order to break ties
- expose only `available_permits` for state observation and keep queue depth, per-key usage, and idle bookkeeping private
- align borrowed and owned permit documentation with the corresponding `Semaphore` types, including acquire/try entry points and drop behavior
- organize waiters as per-key FIFO queues backed by a slab, so scheduling scans contending keys instead of every queued acquisition
- cover fair distribution, tie ordering, cancellation before and after admission, owned permits, custom hash builders, Send futures, and permit-limit stress

This supersedes #114. It preserves the intended scheduling behavior, but deliberately replaces the semaphore-oriented API and flat waiter queue with an admission-domain design.

## Verification

- `cargo x test`
- `cargo x lint`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 check --workspace --all-targets --all-features`
- `cargo package -p mea --allow-dirty`