### PR TITLE
fix: make OwnedMappedMutexGuard invariant over mapped type

### DIFF
--- a/mea/src/guard_variance_tests.rs
+++ b/mea/src/guard_variance_tests.rs
@@ -1,0 +1,137 @@
+// Copyright 2024 tison <wander4096@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Compile-fail tests for mutable guard variance.
+//!
+//! A guard that provides mutable access to its target must be invariant over the target type.
+//!
+//! `MutexGuard`:
+//!
+//! ```compile_fail
+//! use mea::mutex::MutexGuard;
+//!
+//! fn shorten<'lock, 'short: 'lock>(
+//!     guard: MutexGuard<'lock, &'static str>,
+//!     value: &'short str,
+//! ) -> MutexGuard<'lock, &'short str> {
+//!     let mut guard: MutexGuard<'lock, &'short str> = guard;
+//!     *guard = value;
+//!     guard
+//! }
+//! ```
+//!
+//! `OwnedMutexGuard`:
+//!
+//! ```compile_fail
+//! use mea::mutex::OwnedMutexGuard;
+//!
+//! fn shorten<'short>(
+//!     guard: OwnedMutexGuard<&'static str>,
+//!     value: &'short str,
+//! ) -> OwnedMutexGuard<&'short str> {
+//!     let mut guard: OwnedMutexGuard<&'short str> = guard;
+//!     *guard = value;
+//!     guard
+//! }
+//! ```
+//!
+//! `MappedMutexGuard`:
+//!
+//! ```compile_fail
+//! use mea::mutex::MappedMutexGuard;
+//!
+//! fn shorten<'lock, 'short: 'lock>(
+//!     guard: MappedMutexGuard<'lock, &'static str>,
+//!     value: &'short str,
+//! ) -> MappedMutexGuard<'lock, &'short str> {
+//!     let mut guard: MappedMutexGuard<'lock, &'short str> = guard;
+//!     *guard = value;
+//!     guard
+//! }
+//! ```
+//!
+//! `OwnedMappedMutexGuard`:
+//!
+//! ```compile_fail
+//! use mea::mutex::OwnedMappedMutexGuard;
+//!
+//! fn shorten<'short>(
+//!     guard: OwnedMappedMutexGuard<(), &'static str>,
+//!     value: &'short str,
+//! ) -> OwnedMappedMutexGuard<(), &'short str> {
+//!     let mut guard: OwnedMappedMutexGuard<(), &'short str> = guard;
+//!     *guard = value;
+//!     guard
+//! }
+//! ```
+//!
+//! `RwLockWriteGuard`:
+//!
+//! ```compile_fail
+//! use mea::rwlock::RwLockWriteGuard;
+//!
+//! fn shorten<'lock, 'short: 'lock>(
+//!     guard: RwLockWriteGuard<'lock, &'static str>,
+//!     value: &'short str,
+//! ) -> RwLockWriteGuard<'lock, &'short str> {
+//!     let mut guard: RwLockWriteGuard<'lock, &'short str> = guard;
+//!     *guard = value;
+//!     guard
+//! }
+//! ```
+//!
+//! `OwnedRwLockWriteGuard`:
+//!
+//! ```compile_fail
+//! use mea::rwlock::OwnedRwLockWriteGuard;
+//!
+//! fn shorten<'short>(
+//!     guard: OwnedRwLockWriteGuard<&'static str>,
+//!     value: &'short str,
+//! ) -> OwnedRwLockWriteGuard<&'short str> {
+//!     let mut guard: OwnedRwLockWriteGuard<&'short str> = guard;
+//!     *guard = value;
+//!     guard
+//! }
+//! ```
+//!
+//! `MappedRwLockWriteGuard`:
+//!
+//! ```compile_fail
+//! use mea::rwlock::MappedRwLockWriteGuard;
+//!
+//! fn shorten<'lock, 'short: 'lock>(
+//!     guard: MappedRwLockWriteGuard<'lock, &'static str>,
+//!     value: &'short str,
+//! ) -> MappedRwLockWriteGuard<'lock, &'short str> {
+//!     let mut guard: MappedRwLockWriteGuard<'lock, &'short str> = guard;
+//!     *guard = value;
+//!     guard
+//! }
+//! ```
+//!
+//! `OwnedMappedRwLockWriteGuard`:
+//!
+//! ```compile_fail
+//! use mea::rwlock::OwnedMappedRwLockWriteGuard;
+//!
+//! fn shorten<'short>(
+//!     guard: OwnedMappedRwLockWriteGuard<(), &'static str>,
+//!     value: &'short str,
+//! ) -> OwnedMappedRwLockWriteGuard<(), &'short str> {
+//!     let mut guard: OwnedMappedRwLockWriteGuard<(), &'short str> = guard;
+//!     *guard = value;
+//!     guard
+//! }
+//! ```

--- a/mea/src/lib.rs
+++ b/mea/src/lib.rs
@@ -90,6 +90,9 @@ pub mod shutdown;
 pub mod singleflight;
 pub mod waitgroup;
 
+#[cfg(doctest)]
+pub mod guard_variance_tests;
+
 #[cfg(test)]
 fn test_runtime() -> &'static tokio::runtime::Runtime {
     use std::sync::OnceLock;

--- a/mea/src/mutex/mod.rs
+++ b/mea/src/mutex/mod.rs
@@ -674,6 +674,7 @@ pub struct MappedMutexGuard<'a, T: ?Sized> {
     d: NonNull<T>,
     /// Reference to the original mutex's semaphore, used for releasing the lock
     s: &'a internal::Semaphore,
+    // Mutable access requires invariance over T.
     variance: PhantomData<&'a mut T>,
 }
 
@@ -891,24 +892,6 @@ impl<'a, T: ?Sized> MappedMutexGuard<'a, T> {
 /// assert_eq!(*value_guard, 42);
 /// # }
 /// ```
-///
-/// # Compile-time guarantees
-///
-/// The mapped target type is invariant. In particular, a guard mapped to a reference with a
-/// longer lifetime cannot be coerced to one with a shorter lifetime:
-///
-/// ```compile_fail
-/// use mea::mutex::OwnedMappedMutexGuard;
-///
-/// fn shorten<'short>(
-///     guard: OwnedMappedMutexGuard<&'static str, &'static str>,
-///     value: &'short str,
-/// ) -> OwnedMappedMutexGuard<&'static str, &'short str> {
-///     let mut guard: OwnedMappedMutexGuard<&'static str, &'short str> = guard;
-///     *guard = value;
-///     guard
-/// }
-/// ```
 #[must_use = "if unused the Mutex will immediately unlock"]
 pub struct OwnedMappedMutexGuard<T: ?Sized, U: ?Sized> {
     // This Arc acts as an ownership certificate, ensuring the Mutex remains valid
@@ -917,6 +900,7 @@ pub struct OwnedMappedMutexGuard<T: ?Sized, U: ?Sized> {
     // This NonNull pointer precisely points to the subfield U, telling us which
     // memory location we can operate on, with compile-time guarantee of non-null
     d: NonNull<U>,
+    // Mutable access requires invariance over U.
     variance: PhantomData<*mut U>,
 }
 

--- a/mea/src/mutex/mod.rs
+++ b/mea/src/mutex/mod.rs
@@ -891,6 +891,24 @@ impl<'a, T: ?Sized> MappedMutexGuard<'a, T> {
 /// assert_eq!(*value_guard, 42);
 /// # }
 /// ```
+///
+/// # Compile-time guarantees
+///
+/// The mapped target type is invariant. In particular, a guard mapped to a reference with a
+/// longer lifetime cannot be coerced to one with a shorter lifetime:
+///
+/// ```compile_fail
+/// use mea::mutex::OwnedMappedMutexGuard;
+///
+/// fn shorten<'short>(
+///     guard: OwnedMappedMutexGuard<&'static str, &'static str>,
+///     value: &'short str,
+/// ) -> OwnedMappedMutexGuard<&'static str, &'short str> {
+///     let mut guard: OwnedMappedMutexGuard<&'static str, &'short str> = guard;
+///     *guard = value;
+///     guard
+/// }
+/// ```
 #[must_use = "if unused the Mutex will immediately unlock"]
 pub struct OwnedMappedMutexGuard<T: ?Sized, U: ?Sized> {
     // This Arc acts as an ownership certificate, ensuring the Mutex remains valid
@@ -899,7 +917,7 @@ pub struct OwnedMappedMutexGuard<T: ?Sized, U: ?Sized> {
     // This NonNull pointer precisely points to the subfield U, telling us which
     // memory location we can operate on, with compile-time guarantee of non-null
     d: NonNull<U>,
-    variance: PhantomData<U>,
+    variance: PhantomData<*mut U>,
 }
 
 // SAFETY: OwnedMappedMutexGuard can be safely sent between threads when T: Send and U: Send.

--- a/mea/src/rwlock/mapped_write_guard.rs
+++ b/mea/src/rwlock/mapped_write_guard.rs
@@ -85,6 +85,7 @@ pub struct MappedRwLockWriteGuard<'a, T: ?Sized> {
     d: NonNull<T>,
     s: &'a internal::Semaphore,
     permits_acquired: usize,
+    // Mutable access requires invariance over T.
     variance: PhantomData<&'a mut T>,
 }
 

--- a/mea/src/rwlock/owned_mapped_write_guard.rs
+++ b/mea/src/rwlock/owned_mapped_write_guard.rs
@@ -90,6 +90,7 @@ pub struct OwnedMappedRwLockWriteGuard<T: ?Sized, U: ?Sized> {
     d: NonNull<U>,
     lock: Arc<RwLock<T>>,
     permits_acquired: usize,
+    // Mutable access requires invariance over U.
     variance: PhantomData<*mut U>,
 }
 


### PR DESCRIPTION
## Summary

- make the mapped target type of OwnedMappedMutexGuard invariant
- prevent lifetime-shortening coercions that could allow safe code to store a shorter-lived reference in longer-lived storage
- add an internal cfg(doctest) compile-fail suite for all eight mutable Mutex and RwLock guard types
- keep the variance tests out of the rendered public API documentation

## Regression verification

The hidden suite contains one independent compile-fail case for each mutable guard. Restoring the old covariant marker makes exactly the OwnedMappedMutexGuard case fail because the invalid example compiles successfully. Restoring PhantomData<*mut U> makes all eight cases pass.

Read-only mapped guards are intentionally excluded because shared access may remain covariant safely.

## Validation

- cargo fmt --all -- --check
- cargo test --workspace --all-targets --all-features
- cargo test -p mea --doc
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo doc -p mea --no-deps
- cargo +1.85.0 test -p mea --lib --locked
- cargo +1.85.0 test -p mea --doc --locked
- cargo package -p mea --allow-dirty --list