### PR TITLE
fix: tighten OwnedRwLockReadGuard Send bound

### DIFF
--- a/mea/src/guard_send_sync_tests.rs
+++ b/mea/src/guard_send_sync_tests.rs
@@ -1,0 +1,30 @@
+// Copyright 2024 tison <wander4096@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Compile-fail tests for guard `Send` and `Sync` contracts.
+//!
+//! An owned guard can hold the last strong reference to its lock. Moving the guard can therefore
+//! move destruction of the protected value to another thread, so the value must be `Send`.
+//!
+//! `std::sync::MutexGuard` is `Sync` but not `Send`, making it a useful regression case:
+//!
+//! ```compile_fail
+//! use std::sync::MutexGuard;
+//!
+//! use mea::rwlock::OwnedRwLockReadGuard;
+//!
+//! fn assert_send<T: Send>() {}
+//!
+//! assert_send::<OwnedRwLockReadGuard<MutexGuard<'static, ()>>>();
+//! ```

--- a/mea/src/lib.rs
+++ b/mea/src/lib.rs
@@ -87,6 +87,8 @@ pub mod singleflight;
 pub mod waitgroup;
 
 #[cfg(doctest)]
+pub mod guard_send_sync_tests;
+#[cfg(doctest)]
 pub mod guard_variance_tests;
 
 #[cfg(test)]
@@ -114,6 +116,7 @@ mod tests {
     use crate::once::OnceCell;
     use crate::once::OnceMap;
     use crate::oneshot;
+    use crate::rwlock::OwnedRwLockReadGuard;
     use crate::rwlock::RwLock;
     use crate::rwlock::RwLockReadGuard;
     use crate::rwlock::RwLockWriteGuard;
@@ -146,6 +149,7 @@ mod tests {
         do_assert_send_and_sync::<Mutex<i64>>();
         do_assert_send_and_sync::<MutexGuard<'_, i64>>();
         do_assert_send_and_sync::<RwLock<i64>>();
+        do_assert_send_and_sync::<OwnedRwLockReadGuard<i64>>();
         do_assert_send_and_sync::<RwLockReadGuard<'_, i64>>();
         do_assert_send_and_sync::<RwLockWriteGuard<'_, i64>>();
         do_assert_send_and_sync::<broadcast::overflow::Sender<i64>>();
@@ -164,6 +168,7 @@ mod tests {
     #[test]
     fn assert_send() {
         fn do_assert_send<T: Send>() {}
+        do_assert_send::<RwLockReadGuard<'_, std::sync::MutexGuard<'static, ()>>>();
         do_assert_send::<oneshot::Receiver<i64>>();
         do_assert_send::<oneshot::Recv<i64>>();
     }

--- a/mea/src/rwlock/owned_read_guard.rs
+++ b/mea/src/rwlock/owned_read_guard.rs
@@ -117,9 +117,6 @@ pub struct OwnedRwLockReadGuard<T: ?Sized> {
     pub(super) lock: Arc<RwLock<T>>,
 }
 
-unsafe impl<T: ?Sized + Sync> Send for OwnedRwLockReadGuard<T> {}
-unsafe impl<T: ?Sized + Send + Sync> Sync for OwnedRwLockReadGuard<T> {}
-
 impl<T: ?Sized> Drop for OwnedRwLockReadGuard<T> {
     fn drop(&mut self) {
         self.lock.s.release(1);


### PR DESCRIPTION
## Summary

- remove the manual Send and Sync implementations from OwnedRwLockReadGuard
- let Arc<RwLock<T>> derive the correct auto-trait bounds, requiring T: Send + Sync for Send
- add a compile-fail regression using std::sync::MutexGuard as a Sync but non-Send payload
- preserve and test the intentional distinction that a borrowed RwLockReadGuard only needs T: Sync to be Send

## Rationale

An owned read guard may hold the last strong reference to the lock. Moving it to another thread can therefore move destruction of the protected T to that thread. Requiring only T: Sync allowed a thread-affine, non-Send value to be destroyed on the wrong thread through safe code.

The guard contains only Arc<RwLock<T>>, whose auto-trait implementation already captures the correct requirements, so removing the unnecessary unsafe implementations is safer than maintaining duplicate manual bounds.

## Validation

- cargo test --workspace --all-targets --all-features
- cargo test -p mea --doc
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo +1.85.0 test -p mea --lib --locked
- cargo +1.85.0 test -p mea --doc --locked
- cargo doc -p mea --no-deps