### PR TITLE
fix: retry spurious CAS failures in Once

### DIFF
--- a/mea/src/once/once/mod.rs
+++ b/mea/src/once/once/mod.rs
@@ -171,8 +171,9 @@ impl Once {
 
         f().await;
 
-        if let Err(cnt) = self.done.cas_state(1, 0) {
-            unreachable!("[BUG] Once completed more than once: {}", cnt);
+        // `decrement` retries spurious failures from the weak CAS.
+        if !self.done.decrement(1) {
+            unreachable!("[BUG] Once completed more than once");
         }
 
         self.done.wake_all();


### PR DESCRIPTION
## Summary

- replace the one-shot weak CAS in `Once::call_once` with `CountdownState::decrement`
- preserve the single-completion invariant check and waiter wake-up behavior

## Rationale

`compare_exchange_weak` may fail spuriously even when the stored state matches the expected value. `Once` treated any failure after the initialization future completed as unreachable, which could panic and leave the state incomplete. A later caller could then run the initialization operation again, violating the at-most-once guarantee.

`CountdownState::decrement` already retries weak-CAS failures, so using it makes completion robust without changing the public API or memory ordering.

## Verification

- `cargo x test --no-capture`
- `cargo x lint`
- `cargo +1.85.0 test --workspace --no-default-features --no-run`