### PR TITLE
refactor: encapsulate countdown increments

### DIFF
--- a/mea/src/internal/countdown.rs
+++ b/mea/src/internal/countdown.rs
@@ -48,7 +48,7 @@ impl CountdownState {
     ///
     /// @see https://doc.rust-lang.org/std/sync/atomic/struct.AtomicU32.html#method.compare_exchange_weak
     /// @see https://en.cppreference.com/w/cpp/atomic/atomic_compare_exchange
-    pub(crate) fn cas_state(&self, current: u32, new: u32) -> Result<(), u32> {
+    fn cas_state(&self, current: u32, new: u32) -> Result<(), u32> {
         self.state
             .compare_exchange_weak(current, new, Ordering::Release, Ordering::Relaxed)
             .map(|_| ())
@@ -88,6 +88,18 @@ impl CountdownState {
         match self.state() {
             0 => Ok(()),
             s => Err(s),
+        }
+    }
+
+    /// Increments the counter by `n`, saturating at [`u32::MAX`].
+    pub(crate) fn increment(&self, n: u32) {
+        let mut cnt = self.state();
+        loop {
+            let new_cnt = cnt.saturating_add(n);
+            match self.cas_state(cnt, new_cnt) {
+                Ok(_) => return,
+                Err(x) => cnt = x,
+            }
         }
     }
 

--- a/mea/src/waitgroup/mod.rs
+++ b/mea/src/waitgroup/mod.rs
@@ -106,14 +106,8 @@ impl Clone for WaitGroup {
     /// when the new handle is dropped.
     fn clone(&self) -> Self {
         let sync = self.state.clone();
-        let mut cnt = sync.state();
-        loop {
-            let new_cnt = cnt.saturating_add(1);
-            match sync.cas_state(cnt, new_cnt) {
-                Ok(_) => return Self { state: sync },
-                Err(x) => cnt = x,
-            }
-        }
+        sync.increment(1);
+        Self { state: sync }
     }
 }
 


### PR DESCRIPTION
## Summary

- add `CountdownState::increment` with the existing saturating-add and weak-CAS retry behavior
- use the new operation from `WaitGroup::clone`
- make `CountdownState::cas_state` private to the countdown implementation

## Rationale

After #126, `WaitGroup::clone` was the only remaining caller that operated on the countdown state through the raw CAS helper. Its retry loop was correct, but exposing that helper across the crate made it possible to repeat the one-shot weak-CAS mistake.

Keeping the CAS private and exposing semantic increment/decrement operations centralizes the retry requirement without changing behavior or public API.

## Verification

- `cargo test -p mea waitgroup --no-default-features`
- `cargo x test --no-capture`
- `cargo x lint`
- `cargo +1.85.0 test --workspace --no-default-features --no-run`