### PR TITLE
fix: panic on WaitGroup counter overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Bug fixes
+
+* Prevent `OwnedMappedMutexGuard` from allowing invalid lifetime coercions. ([#121](https://github.com/fast/mea/pull/121))
+* Require the protected value of an `OwnedRwLockReadGuard` to be both `Send` and `Sync` before the guard can be sent across threads. ([#122](https://github.com/fast/mea/pull/122))
+* Wake waiting tasks only after releasing internal locks. ([#125](https://github.com/fast/mea/pull/125))
+* Retry spurious atomic failures when completing `Once` initialization. ([#126](https://github.com/fast/mea/pull/126))
+* Make cloning a `WaitGroup` panic on counter overflow instead of silently losing track of a handle.
+
 ## v0.6.5 (2026-07-30)
 
 ### New features

--- a/mea/src/internal/countdown.rs
+++ b/mea/src/internal/countdown.rs
@@ -91,19 +91,23 @@ impl CountdownState {
         }
     }
 
-    /// Increments the counter by `n`, saturating at [`u32::MAX`].
-    pub(crate) fn increment(&self, n: u32) {
+    /// Increments the counter by `n`.
+    ///
+    /// Returns `true` without changing the counter if the operation would overflow.
+    pub(crate) fn increment(&self, n: u32) -> bool {
         let mut cnt = self.state();
         loop {
-            let new_cnt = cnt.saturating_add(n);
+            let Some(new_cnt) = cnt.checked_add(n) else {
+                return true;
+            };
             match self.cas_state(cnt, new_cnt) {
-                Ok(_) => return,
+                Ok(_) => return false,
                 Err(x) => cnt = x,
             }
         }
     }
 
-    /// Decrements the counter, and returns whether the caller should wake up all waiters.
+    /// Decrements the counter by `n`, returning whether the caller should wake up all waiters.
     pub(crate) fn decrement(&self, n: u32) -> bool {
         let mut cnt = self.state();
         loop {
@@ -119,5 +123,18 @@ impl CountdownState {
                 Err(x) => cnt = x,
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn increment_reports_overflow_without_changing_state() {
+        let state = CountdownState::new(u32::MAX);
+
+        assert!(state.increment(1));
+        assert_eq!(state.state(), u32::MAX);
     }
 }

--- a/mea/src/waitgroup/mod.rs
+++ b/mea/src/waitgroup/mod.rs
@@ -104,9 +104,15 @@ impl Clone for WaitGroup {
     ///
     /// This increments the WaitGroup counter. The counter will be decremented
     /// when the new handle is dropped.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the WaitGroup counter would overflow.
     fn clone(&self) -> Self {
         let sync = self.state.clone();
-        sync.increment(1);
+        if sync.increment(1) {
+            panic!("WaitGroup counter overflow");
+        }
         Self { state: sync }
     }
 }

--- a/mea/src/waitgroup/tests.rs
+++ b/mea/src/waitgroup/tests.rs
@@ -19,6 +19,16 @@ use super::*;
 use crate::test_runtime;
 
 #[test]
+#[should_panic(expected = "WaitGroup counter overflow")]
+fn test_clone_panics_on_counter_overflow() {
+    let wg = WaitGroup {
+        state: Arc::new(CountdownState::new(u32::MAX)),
+    };
+
+    let _ = wg.clone();
+}
+
+#[test]
 fn test_wait_group_drop() {
     let wg = WaitGroup::new();
     for _i in 0..100 {


### PR DESCRIPTION
## Summary

- report countdown overflow without changing the counter
- panic when cloning a WaitGroup would exceed the counter limit
- add regression coverage and fill missing Unreleased changelog entries

## Testing

- cargo +1.85.0 test --workspace --all-targets
- cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings
- cargo +nightly fmt --all --check
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --all-features