### PR TITLE
perf: avoid allocating on uncontended semaphore release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Improvements
+
+* Avoid allocating a waker buffer when releasing semaphore permits with no tasks to wake.
+
 ### Bug fixes
 
 * Prevent `OwnedMappedMutexGuard` from allowing invalid lifetime coercions. ([#121](https://github.com/fast/mea/pull/121))

--- a/mea/src/internal/semaphore.rs
+++ b/mea/src/internal/semaphore.rs
@@ -168,7 +168,7 @@ impl Semaphore {
         waiters: MutexGuard<'_, WaitList<WaitNode>>,
     ) {
         const NUM_WAKER: usize = 32;
-        let mut wakers = Vec::with_capacity(NUM_WAKER);
+        let mut wakers = Vec::new();
 
         let mut lock = Some(waiters);
         while rem > 0 {
@@ -188,6 +188,9 @@ impl Semaphore {
                     None => break,
                     Some(waiter) => {
                         if let Some(waker) = waiter.waker.take() {
+                            if wakers.capacity() == 0 {
+                                wakers.reserve_exact(NUM_WAKER);
+                            }
                             wakers.push(waker);
                         }
                     }

--- a/mea/tests/semaphore_allocation.rs
+++ b/mea/tests/semaphore_allocation.rs
@@ -1,0 +1,97 @@
+// Copyright 2024 tison <wander4096@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::alloc::GlobalAlloc;
+use std::alloc::Layout;
+use std::alloc::System;
+use std::cell::Cell;
+
+use mea::semaphore::Semaphore;
+
+struct CountingAllocator;
+
+std::thread_local! {
+    static TRACK_ALLOCATIONS: Cell<bool> = const { Cell::new(false) };
+    static ALLOCATION_COUNT: Cell<usize> = const { Cell::new(0) };
+}
+
+fn record_allocation() {
+    let _ = TRACK_ALLOCATIONS.try_with(|tracking| {
+        if tracking.get() {
+            ALLOCATION_COUNT.with(|count| count.set(count.get() + 1));
+        }
+    });
+}
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        record_allocation();
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        record_allocation();
+        unsafe { System.alloc_zeroed(layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        record_allocation();
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+fn count_allocations(f: impl FnOnce()) -> usize {
+    struct TrackingGuard;
+
+    impl Drop for TrackingGuard {
+        fn drop(&mut self) {
+            TRACK_ALLOCATIONS.with(|tracking| tracking.set(false));
+        }
+    }
+
+    ALLOCATION_COUNT.with(|count| count.set(0));
+    TRACK_ALLOCATIONS.with(|tracking| {
+        assert!(
+            !tracking.replace(true),
+            "allocation tracking is not reentrant"
+        );
+    });
+    let _guard = TrackingGuard;
+
+    f();
+
+    ALLOCATION_COUNT.with(Cell::get)
+}
+
+#[test]
+fn releasing_an_uncontended_permit_does_not_allocate() {
+    let semaphore = Semaphore::new(1);
+
+    // Warm up platform synchronization internals before measuring the steady-state path.
+    drop(semaphore.try_acquire(1).unwrap());
+
+    let permit = semaphore.try_acquire(1).unwrap();
+
+    let allocations = count_allocations(|| drop(permit));
+
+    assert_eq!(allocations, 0);
+    assert_eq!(semaphore.available_permits(), 1);
+}


### PR DESCRIPTION
## Summary

- lazily reserve the 32-entry wake batch only after finding an actual waker
- preserve the existing bounded wake batching and wake-after-unlock behavior
- add an allocation-counting regression test for steady-state uncontended permit release
- record the improvement in the changelog

The regression test reports one allocation on the previous implementation after warm-up and zero with this change. This PR intentionally does not redesign or remove the waiter mutex from the release path.

## Testing

- `cargo test --workspace --all-targets`
- `cargo +1.85.0 test --workspace --no-default-features`
- `cargo +nightly clippy --tests --all-features --all-targets --workspace -- -D warnings`
- `cargo +nightly fmt --all --check`