### PR TITLE
ci: check rustdoc warnings and semver compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,26 @@ jobs:
           tool: typos-cli,taplo-cli,hawkeye
       - run: cargo x lint
 
+  public-api:
+    name: Check public API
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check documentation
+        run: cargo doc --workspace --all-features --no-deps
+        env:
+          RUSTDOCFLAGS: -D warnings
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          package: mea
+          feature-group: all-features
+          rust-toolchain: manual
+
   test:
     name: Run tests
     strategy:
@@ -77,12 +97,14 @@ jobs:
     if: ${{ always() }}
     needs:
       - check
+      - public-api
       - test
     steps:
       - name: Guardian
         run: |
           if [[ ! ( \
                  "${{ needs.check.result }}" == "success" \
+              && "${{ needs.public-api.result }}" == "success" \
               && "${{ needs.test.result }}" == "success" \
               ) ]]; then
             echo "Required jobs haven't been completed successfully."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,25 +39,17 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - name: Install toolchain
+      - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt,clippy
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
           tool: typos-cli,taplo-cli,hawkeye
       - run: cargo x lint
-
-  public-api:
-    name: Check public API
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v6
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
       - name: Check documentation
         run: cargo doc --workspace --all-features --no-deps
         env:
@@ -97,14 +89,12 @@ jobs:
     if: ${{ always() }}
     needs:
       - check
-      - public-api
       - test
     steps:
       - name: Guardian
         run: |
           if [[ ! ( \
                  "${{ needs.check.result }}" == "success" \
-              && "${{ needs.public-api.result }}" == "success" \
               && "${{ needs.test.result }}" == "success" \
               ) ]]; then
             echo "Required jobs haven't been completed successfully."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,18 +48,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
-          tool: typos-cli,taplo-cli,hawkeye
-      - run: cargo x lint
-      - name: Check documentation
-        run: cargo doc --workspace --all-features --no-deps
-        env:
-          RUSTDOCFLAGS: -D warnings
-      - name: Check semver
-        uses: obi1kenobi/cargo-semver-checks-action@v2
-        with:
-          package: mea
-          feature-group: all-features
-          rust-toolchain: manual
+          tool: typos-cli,taplo-cli,hawkeye,cargo-semver-checks
+      - run: cargo +nightly x lint
 
   test:
     name: Run tests

--- a/taplo.toml
+++ b/taplo.toml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+exclude = ["target/**"]
 include = ["Cargo.toml", "**/*.toml"]
 
 [formatting]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -37,7 +37,7 @@ impl Command {
 enum SubCommand {
     #[clap(about = "Compile workspace packages.")]
     Build(CommandBuild),
-    #[clap(about = "Run format and clippy checks.")]
+    #[clap(about = "Run code quality and API compatibility checks.")]
     Lint(CommandLint),
     #[clap(about = "Run unit tests.")]
     Test(CommandTest),
@@ -81,6 +81,8 @@ impl CommandLint {
         run_command(make_taplo_cmd(self.fix));
         run_command(make_typos_cmd());
         run_command(make_hawkeye_cmd(self.fix));
+        run_command(make_doc_cmd());
+        run_command(make_semver_check_cmd());
     }
 }
 
@@ -164,6 +166,33 @@ fn make_clippy_cmd(fix: bool) -> StdCommand {
     } else {
         cmd.args(["--", "-D", "warnings"]);
     }
+    cmd
+}
+
+fn make_doc_cmd() -> StdCommand {
+    let mut cmd = find_command("cargo");
+    cmd.env("RUSTDOCFLAGS", "-D warnings");
+    cmd.args([
+        "+nightly",
+        "doc",
+        "--workspace",
+        "--all-features",
+        "--no-deps",
+    ]);
+    cmd
+}
+
+fn make_semver_check_cmd() -> StdCommand {
+    ensure_installed("cargo-semver-checks", "cargo-semver-checks");
+    let mut cmd = find_command("cargo");
+    cmd.args([
+        "+stable",
+        "semver-checks",
+        "check-release",
+        "--package",
+        "mea",
+        "--all-features",
+    ]);
     cmd
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -171,7 +171,7 @@ fn make_clippy_cmd(fix: bool) -> StdCommand {
 
 fn make_doc_cmd() -> StdCommand {
     let mut cmd = find_command("cargo");
-    cmd.env("RUSTDOCFLAGS", "-D warnings");
+    cmd.env("RUSTDOCFLAGS", "-D warnings --cfg docsrs");
     cmd.args([
         "+nightly",
         "doc",


### PR DESCRIPTION
## Summary

- make `cargo +nightly x lint` the single CI entry point for code quality and public API checks
- run rustdoc with `-D warnings --cfg docsrs` from the xtask on nightly
- run `cargo-semver-checks` for `mea` with all features from the xtask
- install `cargo-semver-checks` through the existing prebuilt tool installer
- exclude generated `target` manifests from Taplo so repeated local and cached CI runs remain stable

The semver command intentionally uses stable even though the xtask itself, clippy, fmt, and rustdoc run on nightly. Rustdoc JSON is unstable: the current nightly emits v61 while the latest `cargo-semver-checks` release supports v56, v57, and v60. Stable is therefore required for a reliable moving-toolchain check.

## Testing

- `cargo +nightly x lint`
  - nightly clippy and fmt
  - Taplo, typos, and license checks
  - nightly docs.rs-style rustdoc with warnings denied
  - 196 semver checks against the latest published `mea` release