### PR TITLE
fix: clean up abandoned keyed once entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 * Retry spurious atomic failures when completing `Once` initialization. ([#126](https://github.com/fast/mea/pull/126))
 * Make cloning a `WaitGroup` panic on counter overflow instead of silently losing track of a handle.
 * Align `Condvar` with standard condition-variable semantics by notifying only current waiters and passing a cancelled `notify_one` wakeup to another current waiter instead of storing a permit.
+* Clean up uninitialized `OnceMap` and `singleflight` entries once no callers remain after a failure, panic, or cancellation.
 
 ## v0.6.5 (2026-07-30)
 

--- a/mea/src/once/once_map/mod.rs
+++ b/mea/src/once/once_map/mod.rs
@@ -65,11 +65,21 @@ impl<V> Entry<V> {
     }
 
     fn acquire(&self) {
-        self.active_calls
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |active_calls| {
-                active_calls.checked_add(1)
-            })
-            .expect("too many concurrent OnceMap calls");
+        let mut active_calls = self.active_calls.load(Ordering::Relaxed);
+        loop {
+            let next = active_calls
+                .checked_add(1)
+                .expect("too many concurrent OnceMap calls");
+            match self.active_calls.compare_exchange_weak(
+                active_calls,
+                next,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return,
+                Err(current) => active_calls = current,
+            }
+        }
     }
 
     fn release(&self) -> bool {

--- a/mea/src/once/once_map/mod.rs
+++ b/mea/src/once/once_map/mod.rs
@@ -14,10 +14,13 @@
 
 use std::borrow::Borrow;
 use std::collections::HashMap;
+use std::fmt;
 use std::hash::BuildHasher;
 use std::hash::Hash;
 use std::hash::RandomState;
 use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 
 use crate::internal::Mutex;
 use crate::once::OnceCell;
@@ -31,7 +34,71 @@ mod tests;
 /// to wrap the `V` in an `Arc<V>` to make cloning cheap.
 #[derive(Debug)]
 pub struct OnceMap<K, V, S = RandomState> {
-    map: Mutex<HashMap<K, Arc<OnceCell<V>>, S>>,
+    map: Mutex<HashMap<K, Arc<Entry<V>>, S>>,
+}
+
+struct Entry<V> {
+    cell: OnceCell<V>,
+    // This counter only tracks entry liveness; the map mutex serializes attachment and cleanup.
+    active_calls: AtomicUsize,
+}
+
+impl<V: fmt::Debug> fmt::Debug for Entry<V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.cell.fmt(f)
+    }
+}
+
+impl<V> Entry<V> {
+    fn new() -> Self {
+        Self {
+            cell: OnceCell::new(),
+            active_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn from_value(value: V) -> Self {
+        Self {
+            cell: OnceCell::from_value(value),
+            active_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn acquire(&self) {
+        self.active_calls
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |active_calls| {
+                active_calls.checked_add(1)
+            })
+            .expect("too many concurrent OnceMap calls");
+    }
+
+    fn release(&self) -> bool {
+        let active_calls = self.active_calls.fetch_sub(1, Ordering::Relaxed);
+        debug_assert!(active_calls > 0);
+        active_calls == 1
+    }
+}
+
+struct EntryGuard<'a, K, V, S> {
+    map: &'a Mutex<HashMap<K, Arc<Entry<V>>, S>>,
+    entry: Arc<Entry<V>>,
+}
+
+impl<K, V, S> Drop for EntryGuard<'_, K, V, S> {
+    fn drop(&mut self) {
+        if !self.entry.release() || self.entry.cell.get().is_some() {
+            return;
+        }
+
+        let mut map = self.map.lock();
+        if self.entry.active_calls.load(Ordering::Relaxed) != 0 || self.entry.cell.get().is_some() {
+            return;
+        }
+
+        // K does not need to be Clone, so locate the failed entry by Arc identity. This scan only
+        // runs when the last caller leaves an entry uninitialized.
+        map.retain(|_, entry| !Arc::ptr_eq(entry, &self.entry));
+    }
 }
 
 impl<K, V, S> Default for OnceMap<K, V, S>
@@ -89,21 +156,31 @@ where
     ///
     /// If the value for the key is already being computed by another task, this task will wait for
     /// the computation to finish and return the result.
+    ///
+    /// If the computation is cancelled or panics, another current caller may retry it. The empty
+    /// entry is removed once no current callers remain.
     pub async fn compute<F>(&self, key: K, func: F) -> V
     where
         F: AsyncFnOnce() -> V,
     {
         // 1. Get or create the OnceCell.
-        let cell = {
+        let entry = {
             let mut map = self.map.lock();
-            map.entry(key)
-                .or_insert_with(|| Arc::new(OnceCell::new()))
-                .clone()
+            let entry = map
+                .entry(key)
+                .or_insert_with(|| Arc::new(Entry::new()))
+                .clone();
+            entry.acquire();
+            entry
+        };
+        let guard = EntryGuard {
+            map: &self.map,
+            entry,
         };
 
         // 2. Try to initialize the cell.
         // OnceCell::get_or_init guarantees that only one task executes the closure.
-        let res = cell.get_or_init(func).await;
+        let res = guard.entry.cell.get_or_init(func).await;
         res.clone()
     }
 
@@ -113,22 +190,30 @@ where
     /// the computation to finish and return the result.
     ///
     /// If the computation fails, the error is returned and the value is not stored. Other tasks
-    /// waiting for the value will retry the computation.
+    /// waiting for the value will retry the computation. Once no current callers remain, the empty
+    /// entry is removed.
     pub async fn try_compute<E, F>(&self, key: K, func: F) -> Result<V, E>
     where
         F: AsyncFnOnce() -> Result<V, E>,
     {
         // 1. Get or create the OnceCell.
-        let cell = {
+        let entry = {
             let mut map = self.map.lock();
-            map.entry(key)
-                .or_insert_with(|| Arc::new(OnceCell::new()))
-                .clone()
+            let entry = map
+                .entry(key)
+                .or_insert_with(|| Arc::new(Entry::new()))
+                .clone();
+            entry.acquire();
+            entry
+        };
+        let guard = EntryGuard {
+            map: &self.map,
+            entry,
         };
 
         // 2. Try to initialize the cell.
         // OnceCell::get_or_try_init guarantees that only one task executes the closure.
-        let res = cell.get_or_try_init(func).await?;
+        let res = guard.entry.cell.get_or_try_init(func).await?;
         Ok(res.clone())
     }
 
@@ -139,8 +224,8 @@ where
         Q: Hash + Eq + ?Sized,
     {
         let map = self.map.lock();
-        let cell = map.get(key)?;
-        cell.get().cloned()
+        let entry = map.get(key)?;
+        entry.cell.get().cloned()
     }
 
     /// Remove the given key from the map.
@@ -168,8 +253,8 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let cell = self.map.lock().remove(key)?;
-        cell.get().cloned()
+        let entry = self.map.lock().remove(key)?;
+        entry.cell.get().cloned()
     }
 }
 
@@ -183,7 +268,7 @@ where
         Self {
             map: Mutex::new(
                 iter.into_iter()
-                    .map(|(k, v)| (k, Arc::new(OnceCell::from_value(v))))
+                    .map(|(k, v)| (k, Arc::new(Entry::from_value(v))))
                     .collect(),
             ),
         }

--- a/mea/src/once/once_map/tests.rs
+++ b/mea/src/once/once_map/tests.rs
@@ -75,6 +75,7 @@ async fn test_try_compute() {
     // Fail first
     let res: Result<i32, &str> = map.try_compute("key", async || Err("fail")).await;
     assert_eq!(res, Err("fail"));
+    assert!(map.map.lock().is_empty());
 
     // Success then
     let res: Result<i32, &str> = map.try_compute("key", async || Ok::<i32, &str>(1)).await;
@@ -83,6 +84,29 @@ async fn test_try_compute() {
     // Cached
     let res: Result<i32, &str> = map.try_compute("key", async || Ok::<i32, &str>(2)).await;
     assert_eq!(res, Ok(1));
+}
+
+#[tokio::test]
+async fn test_cancelled_compute_removes_empty_entry() {
+    let map = Arc::new(OnceMap::<&str, i32>::new());
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+    let map_clone = map.clone();
+    let task = tokio::spawn(async move {
+        map_clone
+            .compute("key", async move || {
+                started_tx.send(()).unwrap();
+                std::future::pending().await
+            })
+            .await
+    });
+
+    started_rx.await.unwrap();
+    assert_eq!(map.map.lock().len(), 1);
+
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
+    assert!(map.map.lock().is_empty());
 }
 
 #[tokio::test]
@@ -122,6 +146,8 @@ async fn test_try_compute_concurrent_failure_then_success() {
     let res2 = t2.await.unwrap();
     assert_eq!(res2, Ok(1));
     assert!(success.load(Ordering::SeqCst));
+    assert_eq!(map.map.lock().len(), 1);
+    assert_eq!(map.get("key"), Some(1));
 }
 
 #[tokio::test]

--- a/mea/src/singleflight/mod.rs
+++ b/mea/src/singleflight/mod.rs
@@ -16,10 +16,13 @@
 
 use std::borrow::Borrow;
 use std::collections::HashMap;
+use std::fmt;
 use std::hash::BuildHasher;
 use std::hash::Hash;
 use std::hash::RandomState;
 use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 
 use crate::internal::Mutex;
 use crate::once::OnceCell;
@@ -31,7 +34,80 @@ mod tests;
 /// units of work can be executed with duplicate suppression.
 #[derive(Debug)]
 pub struct Group<K, V, S = RandomState> {
-    map: Mutex<HashMap<K, Arc<OnceCell<V>>, S>>,
+    map: Mutex<HashMap<K, Arc<Entry<V>>, S>>,
+}
+
+struct Entry<V> {
+    cell: OnceCell<V>,
+    // This counter only tracks entry liveness; the map mutex serializes attachment and cleanup.
+    active_calls: AtomicUsize,
+}
+
+impl<V: fmt::Debug> fmt::Debug for Entry<V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.cell.fmt(f)
+    }
+}
+
+impl<V> Entry<V> {
+    fn new() -> Self {
+        Self {
+            cell: OnceCell::new(),
+            active_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn acquire(&self) {
+        self.active_calls
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |active_calls| {
+                active_calls.checked_add(1)
+            })
+            .expect("too many concurrent singleflight calls");
+    }
+
+    fn release(&self) -> bool {
+        let active_calls = self.active_calls.fetch_sub(1, Ordering::Relaxed);
+        debug_assert!(active_calls > 0);
+        active_calls == 1
+    }
+}
+
+struct EntryGuard<'a, K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    map: &'a Mutex<HashMap<K, Arc<Entry<V>>, S>>,
+    key: &'a K,
+    entry: Arc<Entry<V>>,
+}
+
+impl<K, V, S> Drop for EntryGuard<'_, K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    fn drop(&mut self) {
+        if !self.entry.release() || self.entry.cell.get().is_some() {
+            return;
+        }
+
+        // Keep the empty entry reachable while another caller can retry it. Removing it on the
+        // first failed or cancelled attempt could let a new caller start a separate computation
+        // alongside callers that are already waiting on this entry.
+        let removed = {
+            let mut map = self.map.lock();
+            let should_remove = self.entry.active_calls.load(Ordering::Relaxed) == 0
+                && self.entry.cell.get().is_none()
+                && map
+                    .get(self.key)
+                    .is_some_and(|entry| Arc::ptr_eq(entry, &self.entry));
+
+            should_remove.then(|| map.remove_entry(self.key)).flatten()
+        };
+
+        drop(removed);
+    }
 }
 
 impl<K, V, S> Default for Group<K, V, S>
@@ -76,6 +152,9 @@ where
     ///
     /// If a duplicate comes in, the duplicate caller waits for the original to complete and
     /// receives the same results.
+    ///
+    /// If the computation is cancelled or panics, another current caller may retry it. The empty
+    /// entry is removed once no current callers remain.
     ///
     /// Once the function completes, the key, if not [`forgotten`], is removed from the group,
     /// allowing future calls with the same key to execute the function again.
@@ -125,16 +204,26 @@ where
         F: AsyncFnOnce() -> V,
     {
         // 1. Get or create the OnceCell.
-        let cell = {
+        let entry = {
             let mut map = self.map.lock();
-            map.entry(key.clone())
-                .or_insert_with(|| Arc::new(OnceCell::new()))
-                .clone()
+            let entry = map
+                .entry(key.clone())
+                .or_insert_with(|| Arc::new(Entry::new()))
+                .clone();
+            entry.acquire();
+            entry
+        };
+        let guard = EntryGuard {
+            map: &self.map,
+            key: &key,
+            entry,
         };
 
         // 2. Try to initialize the cell.
         // OnceCell::get_or_init guarantees that only one task executes the closure.
-        let res = cell
+        let res = guard
+            .entry
+            .cell
             .get_or_init(async || {
                 let result = func().await;
 
@@ -143,7 +232,7 @@ where
                 let mut map = self.map.lock();
                 if let Some(existing) = map.get(&key) {
                     // Check if the map still points to our cell.
-                    if Arc::ptr_eq(&cell, existing) {
+                    if Arc::ptr_eq(&guard.entry, existing) {
                         map.remove(&key);
                     }
                 }
@@ -162,7 +251,8 @@ where
     /// receives the same results.
     ///
     /// If the computation fails, the error is returned for the caller. Other tasks waiting for the
-    /// result will retry the computation.
+    /// result will retry the computation. If the computation fails, is cancelled or panics and no
+    /// current callers remain, the empty entry is removed.
     ///
     /// Once the function completes successfully, the key, if not [`forgotten`], is removed from
     /// the group, allowing future calls with the same key to execute the function again.
@@ -206,16 +296,26 @@ where
         F: AsyncFnOnce() -> Result<V, E>,
     {
         // 1. Get or create the OnceCell.
-        let cell = {
+        let entry = {
             let mut map = self.map.lock();
-            map.entry(key.clone())
-                .or_insert_with(|| Arc::new(OnceCell::new()))
-                .clone()
+            let entry = map
+                .entry(key.clone())
+                .or_insert_with(|| Arc::new(Entry::new()))
+                .clone();
+            entry.acquire();
+            entry
+        };
+        let guard = EntryGuard {
+            map: &self.map,
+            key: &key,
+            entry,
         };
 
         // 2. Try to initialize the cell.
         // OnceCell::get_or_try_init guarantees that only one task executes the closure.
-        let res = cell
+        let res = guard
+            .entry
+            .cell
             .get_or_try_init(async || {
                 let result = func().await?;
 
@@ -224,7 +324,7 @@ where
                 let mut map = self.map.lock();
                 if let Some(existing) = map.get(&key) {
                     // Check if the map still points to our cell.
-                    if Arc::ptr_eq(&cell, existing) {
+                    if Arc::ptr_eq(&guard.entry, existing) {
                         map.remove(&key);
                     }
                 }

--- a/mea/src/singleflight/mod.rs
+++ b/mea/src/singleflight/mod.rs
@@ -58,11 +58,21 @@ impl<V> Entry<V> {
     }
 
     fn acquire(&self) {
-        self.active_calls
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |active_calls| {
-                active_calls.checked_add(1)
-            })
-            .expect("too many concurrent singleflight calls");
+        let mut active_calls = self.active_calls.load(Ordering::Relaxed);
+        loop {
+            let next = active_calls
+                .checked_add(1)
+                .expect("too many concurrent singleflight calls");
+            match self.active_calls.compare_exchange_weak(
+                active_calls,
+                next,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return,
+                Err(current) => active_calls = current,
+            }
+        }
     }
 
     fn release(&self) -> bool {

--- a/mea/src/singleflight/tests.rs
+++ b/mea/src/singleflight/tests.rs
@@ -137,10 +137,107 @@ async fn test_panic_safe() {
     // Wait for h1 to panic and exit
     let err = h1.await.unwrap_err();
     assert!(err.is_panic());
+    assert!(group.map.lock().is_empty());
 
     // Next task should succeed (new attempt)
     let res = group.work("key", || async { "success".to_string() }).await;
     assert_eq!(res, "success");
+}
+
+#[tokio::test]
+async fn test_cancelled_work_removes_empty_entry() {
+    let group = Arc::new(Group::<&str, &str>::new());
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+    let group_clone = group.clone();
+    let task = tokio::spawn(async move {
+        group_clone
+            .work("key", || async move {
+                started_tx.send(()).unwrap();
+                std::future::pending().await
+            })
+            .await
+    });
+
+    started_rx.await.unwrap();
+    assert_eq!(group.map.lock().len(), 1);
+
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
+    assert!(group.map.lock().is_empty());
+}
+
+#[tokio::test]
+async fn test_cancelled_work_keeps_entry_for_existing_waiters() {
+    let group = Arc::new(Group::<&str, &str>::new());
+    let (first_started_tx, first_started_rx) = tokio::sync::oneshot::channel();
+
+    let group_clone = group.clone();
+    let first = tokio::spawn(async move {
+        group_clone
+            .work("key", || async move {
+                first_started_tx.send(()).unwrap();
+                std::future::pending().await
+            })
+            .await
+    });
+    first_started_rx.await.unwrap();
+
+    let original_entry = group.map.lock().get("key").unwrap().clone();
+    let retry_release = Arc::new(tokio::sync::Notify::new());
+    let (retry_started_tx, retry_started_rx) = tokio::sync::oneshot::channel();
+    let group_clone = group.clone();
+    let retry_release_clone = retry_release.clone();
+    let retry = tokio::spawn(async move {
+        group_clone
+            .work("key", || async move {
+                retry_started_tx.send(()).unwrap();
+                retry_release_clone.notified().await;
+                "retry"
+            })
+            .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while original_entry.active_calls.load(Ordering::Relaxed) != 2 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+
+    first.abort();
+    assert!(first.await.unwrap_err().is_cancelled());
+    retry_started_rx.await.unwrap();
+
+    let current_entry = group.map.lock().get("key").unwrap().clone();
+    assert!(Arc::ptr_eq(&original_entry, &current_entry));
+
+    let unexpected_calls = Arc::new(AtomicUsize::new(0));
+    let group_clone = group.clone();
+    let unexpected_calls_clone = unexpected_calls.clone();
+    let duplicate = tokio::spawn(async move {
+        group_clone
+            .work("key", || async move {
+                unexpected_calls_clone.fetch_add(1, Ordering::SeqCst);
+                "duplicate"
+            })
+            .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while original_entry.active_calls.load(Ordering::Relaxed) != 2 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+
+    retry_release.notify_one();
+    assert_eq!(retry.await.unwrap(), "retry");
+    assert_eq!(duplicate.await.unwrap(), "retry");
+    assert_eq!(unexpected_calls.load(Ordering::SeqCst), 0);
+    assert!(group.map.lock().is_empty());
 }
 
 #[tokio::test]
@@ -192,6 +289,7 @@ async fn test_try_work_failure() {
         .try_work("key", || async { Err::<&str, &str>("error") })
         .await;
     assert_eq!(res, Err("error"));
+    assert!(group.map.lock().is_empty());
 
     // Retry should work
     let res2 = group


### PR DESCRIPTION
## Summary

- clean up uninitialized singleflight and OnceMap entries after the last active call fails, panics, or is cancelled
- keep the original entry while existing callers can still retry, preventing two concurrent computation groups for the same key
- document the cleanup and retry behavior and add a changelog entry

## Why

OnceCell resets after an error or cancellation, but the surrounding map previously retained the empty cell and its key indefinitely. Removing the entry immediately on the first failed call is unsafe because callers already waiting on that cell still retry it; a new caller could otherwise create a second cell and run the same key concurrently.

Each entry now tracks active calls with an RAII guard. The last guard rechecks the entry under the map mutex and removes it only when it is still current and uninitialized. OnceMap locates the entry by Arc identity during this exceptional cleanup path, preserving its existing non-Clone key support.

## Tests

- cargo x lint
- cargo +1.85.0 test --workspace --all-targets
- cargo +1.85.0 test --workspace --no-default-features

The final test run passed 213 unit tests and 146 doctests.