### PR TITLE
docs(barrier): clarify cancellation semantics

### DIFF
--- a/mea/src/barrier/mod.rs
+++ b/mea/src/barrier/mod.rs
@@ -189,6 +189,20 @@ impl Barrier {
     /// The last task to call `wait()` will be designated as the leader and receive `true`
     /// as the return value. All other tasks will receive `false`.
     ///
+    /// # Cancel safety
+    ///
+    /// This method is not cancellation safe.
+    ///
+    /// An arrival is recorded when the future returned by `wait` is first polled. Once recorded,
+    /// the arrival is not retracted if that future is dropped before the barrier completes.
+    /// Cancellation therefore stops that caller from observing completion, but it does not make the
+    /// caller leave the current barrier generation.
+    ///
+    /// Calling `wait` again after canceling a pending call records another arrival. Repeatedly
+    /// canceling and retrying can therefore cause a generation to complete with fewer than `n` live
+    /// wait futures. Callers that need to keep waiting after another operation completes first
+    /// should retain and continue polling the same `wait` future instead of creating a new one.
+    ///
     /// # Returns
     ///
     /// Returns a `Future` that resolves to:

--- a/mea/src/barrier/tests.rs
+++ b/mea/src/barrier/tests.rs
@@ -69,6 +69,18 @@ fn tango() {
 }
 
 #[test]
+fn cancelled_wait_still_counts_as_arrival() {
+    let b = Barrier::new(2);
+
+    let mut cancelled = spawn(b.wait());
+    assert_pending!(cancelled.poll());
+    drop(cancelled);
+
+    let mut remaining = spawn(b.wait());
+    assert!(assert_ready!(remaining.poll()).is_leader());
+}
+
+#[test]
 fn lots() {
     let b = Barrier::new(100);
 


### PR DESCRIPTION
## Summary

- document when `Barrier::wait` records an arrival
- clarify that canceling a pending wait does not retract that arrival
- explain why canceling and retrying is not cancellation safe
- add a regression test for the documented behavior

## Rationale

Barrier arrivals are intentionally irrevocable: once a wait future is polled, canceling it only stops that caller from observing completion. A later `wait` call records a new arrival. The documentation now states this behavior directly instead of implying that cancellation should roll back participation.

## Tests

- `cargo fmt --all --check`
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings --cfg docsrs" cargo +nightly doc --workspace --all-features --no-deps`
- `cargo +1.85.0 test -p mea barrier --locked`