### PR TITLE
feat: add initial support for explicitly driven timers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +234,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +413,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,9 +452,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "mea"
 version = "0.6.5"
 dependencies = [
+ "loom",
  "pollster",
  "slab",
  "tokio",
@@ -445,6 +498,15 @@ checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -564,6 +626,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +690,18 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -665,6 +756,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -754,6 +854,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -847,6 +956,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +1078,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,6 +1118,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ MEA is a runtime-agnostic library providing essential synchronization primitives
 * [**oneshot::channel**](https://docs.rs/mea/*/mea/oneshot/): A one-shot channel for sending a single value between tasks.
 * [**shutdown**](https://docs.rs/mea/*/mea/shutdown/): A composite synchronization primitive for managing shutdown signals.
 * [**singleflight::Group**](https://docs.rs/mea/*/mea/singleflight/): A duplicate function call suppression mechanism.
+* [**time**](https://docs.rs/mea/*/mea/time/): Explicitly driven delays, timeouts, intervals, and scheduled actions that do not require a particular async runtime.
 
 ## Installation
 
@@ -84,6 +85,7 @@ This crate collects runtime-agnostic synchronization primitives from spare parts
 * **atomicbox** is forked from [`atomicbox`](https://github.com/jorendorff/atomicbox/) at commit 07756444.
 * **broadcast::channel** is derived from `tokio::sync::broadcast::channel`, with a different implementation based on the internal `WaitSet` primitive.
 * **oneshot::channel** is derived from [`oneshot`](https://github.com/faern/oneshot), with significant simplifications since we need not support synchronized receiving functions.
+* **time** is built around an explicit driver/context pair. The driver owns a private hierarchical timing wheel and is advanced by the integrating reactor; timeout, interval, and scheduling APIs compose over the context without spawning tasks or using a process-global runtime handle.
 
 Other parts are written from scratch.
 

--- a/mea/Cargo.toml
+++ b/mea/Cargo.toml
@@ -36,6 +36,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 slab = { version = "0.4.11" }
 
 [dev-dependencies]
+loom = "0.7.2"
 pollster = { version = "1.0.1", features = ["macro"] }
 tokio = { version = "1.53.1", features = ["full"] }
 tokio-test = { version = "0.4.5" }

--- a/mea/src/lib.rs
+++ b/mea/src/lib.rs
@@ -44,6 +44,8 @@
 //! * [`oneshot::channel`]: A one-shot channel for sending a single value between tasks.
 //! * [`shutdown`]: A composite synchronization primitive for managing shutdown signals.
 //! * [`singleflight::Group`]: A duplicate function call suppression mechanism.
+//! * [`time`]: Explicitly driven delays, timeouts, intervals, and scheduled actions that do not
+//!   require a particular async runtime.
 //!
 //! # Runtime Agnostic
 //!
@@ -84,6 +86,7 @@ pub mod rwlock;
 pub mod semaphore;
 pub mod shutdown;
 pub mod singleflight;
+pub mod time;
 pub mod waitgroup;
 
 #[cfg(doctest)]
@@ -123,6 +126,10 @@ mod tests {
     use crate::shutdown::ShutdownSend;
     use crate::shutdown::ShutdownWatch;
     use crate::singleflight;
+    use crate::time::Delay;
+    use crate::time::Interval;
+    use crate::time::TimerContext;
+    use crate::time::TimerDriver;
     use crate::waitgroup::Wait;
     use crate::waitgroup::WaitGroup;
 
@@ -161,6 +168,10 @@ mod tests {
         do_assert_send_and_sync::<mpsc::UnboundedReceiver<i64>>();
         do_assert_send_and_sync::<mpsc::BoundedSender<i64>>();
         do_assert_send_and_sync::<mpsc::BoundedReceiver<i64>>();
+        do_assert_send_and_sync::<TimerContext>();
+        do_assert_send_and_sync::<TimerDriver>();
+        do_assert_send_and_sync::<Delay>();
+        do_assert_send_and_sync::<Interval>();
     }
 
     #[test]
@@ -208,5 +219,7 @@ mod tests {
         do_assert_unpin::<mpsc::UnboundedReceiver<i64>>();
         do_assert_unpin::<mpsc::BoundedSender<i64>>();
         do_assert_unpin::<mpsc::BoundedReceiver<i64>>();
+        do_assert_unpin::<Delay>();
+        do_assert_unpin::<Interval>();
     }
 }

--- a/mea/src/time/mod.rs
+++ b/mea/src/time/mod.rs
@@ -1,0 +1,1150 @@
+// Copyright 2024 tison <wander4096@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Runtime-independent timer primitives driven by an explicit reactor context.
+//!
+//! [`TimerDriver`] owns time advancement. It starts no thread and opens no I/O resource; an event
+//! loop calls [`TimerDriver::turn`] and uses [`TimerDriver::next_poll_at`] to choose its next poll
+//! deadline. Tasks receive a cloneable [`TimerContext`] and create lazy [`Delay`] futures from it.
+//!
+//! # Reactor contract
+//!
+//! After each timer turn, the integrating event loop must:
+//!
+//! 1. use a zero timeout when [`TurnResult::has_more_work`] is true;
+//! 2. otherwise call [`TimerDriver::register_wake`] before parking and use a zero timeout if it
+//!    returns `false`;
+//! 3. only after a successful registration, read [`TimerDriver::next_poll_at`] and calculate the
+//!    timeout against a fresh clock observation.
+//!
+//! Even when timer work remains, the reactor should perform one non-blocking I/O poll and dispatch
+//! ready I/O before calling `turn` again. This preserves progress for both sources.
+//!
+//! # Resolution
+//!
+//! The driver uses a 1 ms scheduling resolution. Future deadlines are rounded up to the next tick,
+//! so a timer never fires early because of wheel rounding, but may become ready up to one tick
+//! after its requested deadline in addition to any reactor wake-up delay.
+//!
+//! # Examples
+//!
+//! ```
+//! use std::future::Future;
+//! use std::pin::pin;
+//! use std::task::Context;
+//! use std::task::Poll;
+//! use std::task::Waker;
+//! use std::time::Duration;
+//! use std::time::Instant;
+//!
+//! use mea::time::TimerDriver;
+//! use mea::time::TurnBudget;
+//!
+//! let start = Instant::now();
+//! let deadline = start + Duration::from_millis(10);
+//! let (mut driver, timer) = TimerDriver::new_at(start);
+//! let mut delay = pin!(timer.delay_until(deadline));
+//! let mut cx = Context::from_waker(Waker::noop());
+//!
+//! assert!(delay.as_mut().poll(&mut cx).is_pending());
+//! // The first poll queued a registration, so a reactor may not park yet.
+//! assert!(!driver.register_wake(Waker::noop()));
+//! assert!(!driver.turn(start, TurnBudget::default()).has_more_work());
+//!
+//! // With the queue drained, the reactor can arm its wake and use the timer deadline.
+//! assert!(driver.register_wake(Waker::noop()));
+//! assert_eq!(driver.next_poll_at(), Some(deadline));
+//! let _ = driver.turn(start + Duration::from_millis(10), TurnBudget::default());
+//! assert!(matches!(delay.as_mut().poll(&mut cx), Poll::Ready(Ok(()))));
+//! ```
+
+#[cfg(test)]
+mod tests;
+mod wheel;
+
+use std::fmt;
+use std::future::Future;
+use std::future::poll_fn;
+use std::num::NonZeroUsize;
+use std::ops::AsyncFnMut;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::OnceLock;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::atomic::fence;
+use std::task::Context;
+use std::task::Poll;
+use std::task::Waker;
+use std::time::Duration;
+use std::time::Instant;
+
+use crate::atomicbox::AtomicOptionBox;
+use crate::mpsc;
+use crate::mpsc::TryRecvError;
+use crate::time::wheel::Deadline;
+use crate::time::wheel::Step;
+use crate::time::wheel::Wheel;
+
+const STATE_SUBMITTED: u8 = 0;
+const STATE_REGISTERED: u8 = 1;
+const STATE_FIRED: u8 = 2;
+const STATE_CANCELLED: u8 = 3;
+const STATE_CLOSED: u8 = 4;
+const NO_SLOT: usize = usize::MAX;
+
+/// Work admitted during one [`TimerDriver::turn`].
+///
+/// The default admits up to 1,024 operation-queue messages and 4,096 timer entries per turn.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TurnBudget {
+    max_operations: NonZeroUsize,
+    max_timer_entries: NonZeroUsize,
+}
+
+impl TurnBudget {
+    /// Creates a turn budget from non-zero operation and timer-entry limits.
+    pub const fn new(max_operations: NonZeroUsize, max_timer_entries: NonZeroUsize) -> Self {
+        Self {
+            max_operations,
+            max_timer_entries,
+        }
+    }
+
+    /// Returns the maximum number of operation-queue messages processed by one turn.
+    pub const fn max_operations(self) -> NonZeroUsize {
+        self.max_operations
+    }
+
+    /// Returns the maximum number of wheel entries examined by one turn.
+    pub const fn max_timer_entries(self) -> NonZeroUsize {
+        self.max_timer_entries
+    }
+}
+
+impl Default for TurnBudget {
+    fn default() -> Self {
+        Self::new(
+            NonZeroUsize::new(1024).unwrap(),
+            NonZeroUsize::new(4096).unwrap(),
+        )
+    }
+}
+
+/// The result of one [`TimerDriver::turn`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[must_use = "the reactor must inspect whether timer work remains"]
+pub struct TurnResult {
+    has_more_work: bool,
+}
+
+impl TurnResult {
+    /// Returns whether immediately runnable timer work remains.
+    ///
+    /// An integrating reactor must not block when this is `true`, but should still give I/O one
+    /// non-blocking poll between timer turns.
+    pub const fn has_more_work(self) -> bool {
+        self.has_more_work
+    }
+}
+
+/// Error returned when the driver backing a timer context has been dropped.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TimerClosed;
+
+impl fmt::Display for TimerClosed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("timer driver is closed")
+    }
+}
+
+impl std::error::Error for TimerClosed {}
+
+#[derive(Clone, Copy)]
+enum ClockMode {
+    System,
+    Driven,
+}
+
+struct DriverWake {
+    pending: AtomicBool,
+    slot: AtomicOptionBox<Waker>,
+}
+
+impl DriverWake {
+    fn new() -> Self {
+        Self {
+            pending: AtomicBool::new(false),
+            slot: AtomicOptionBox::none(),
+        }
+    }
+
+    fn notify_after_send(&self) {
+        // ORDERING: Paired with `mark_empty`; the completed channel send precedes this fence.
+        fence(Ordering::SeqCst);
+        let first = !self.pending.swap(true, Ordering::AcqRel);
+        // ORDERING: Paired with `arm`; the pending publication precedes this fence. It remains
+        // unconditional because a producer that finds `pending` set can race a concurrent clear.
+        fence(Ordering::SeqCst);
+        if !first {
+            return;
+        }
+        if let Some(waker) = self.slot.take() {
+            waker.wake();
+        }
+    }
+
+    fn arm(&self, waker: &Waker) -> bool {
+        self.slot.store(Some(Box::new(waker.clone())));
+        // ORDERING: Paired with `notify_after_send`; acquire/release on separate atomics is
+        // insufficient.
+        fence(Ordering::SeqCst);
+        if self.pending.load(Ordering::Acquire) {
+            drop(self.slot.take());
+            false
+        } else {
+            true
+        }
+    }
+
+    fn mark_empty(&self) {
+        self.pending.store(false, Ordering::Release);
+        // ORDERING: Paired with the leading fence in `notify_after_send`. The caller rechecks the
+        // queue immediately after this clear; without a store-load barrier the driver could both
+        // overwrite a producer's `pending` and miss its queued operation.
+        fence(Ordering::SeqCst);
+    }
+
+    fn mark_pending(&self) {
+        self.pending.store(true, Ordering::Release);
+    }
+
+    fn is_pending(&self) -> bool {
+        self.pending.load(Ordering::Acquire)
+    }
+
+    fn disarm(&self) {
+        drop(self.slot.take());
+    }
+}
+
+struct Shared {
+    clock_mode: ClockMode,
+    closed: AtomicBool,
+    observed: Mutex<Instant>,
+    wake: DriverWake,
+}
+
+impl Shared {
+    fn observation(&self) -> Instant {
+        let published = *self
+            .observed
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match self.clock_mode {
+            ClockMode::System => Instant::now().max(published),
+            ClockMode::Driven => published,
+        }
+    }
+}
+
+struct DelayWakeSlot(AtomicOptionBox<Waker>);
+
+impl DelayWakeSlot {
+    fn new() -> Self {
+        Self(AtomicOptionBox::none())
+    }
+
+    fn register_and_load(&self, waker: &Waker, lifecycle: &AtomicU8) -> u8 {
+        self.0.store(Some(Box::new(waker.clone())));
+        // ORDERING: Paired with `take_after_publish`; both sides may not miss the other's store.
+        fence(Ordering::SeqCst);
+        lifecycle.load(Ordering::Acquire)
+    }
+
+    fn take_after_publish(&self) -> Option<Waker> {
+        // ORDERING: Paired with `register_and_load`; the lifecycle transition precedes this fence.
+        fence(Ordering::SeqCst);
+        self.0.take().map(|waker| *waker)
+    }
+
+    fn clear(&self) {
+        drop(self.0.take());
+    }
+}
+
+struct TimerState {
+    fired_at: OnceLock<Instant>,
+    lifecycle: AtomicU8,
+    slot: AtomicUsize,
+    waker: DelayWakeSlot,
+}
+
+impl TimerState {
+    fn new() -> Self {
+        Self {
+            fired_at: OnceLock::new(),
+            lifecycle: AtomicU8::new(STATE_SUBMITTED),
+            slot: AtomicUsize::new(NO_SLOT),
+            waker: DelayWakeSlot::new(),
+        }
+    }
+
+    fn publish_terminal(&self, from: u8, to: u8) -> Option<Waker> {
+        if self
+            .lifecycle
+            .compare_exchange(from, to, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            self.waker.take_after_publish()
+        } else {
+            None
+        }
+    }
+}
+
+struct RegisterOp {
+    deadline: Deadline,
+    state: Option<Arc<TimerState>>,
+}
+
+impl RegisterOp {
+    fn into_state(mut self) -> Arc<TimerState> {
+        self.state.take().expect("register op must own its state")
+    }
+}
+
+impl Drop for RegisterOp {
+    fn drop(&mut self) {
+        let Some(state) = self.state.take() else {
+            return;
+        };
+        if let Some(waker) = state.publish_terminal(STATE_SUBMITTED, STATE_CLOSED) {
+            waker.wake();
+        }
+    }
+}
+
+enum Operation {
+    Register(RegisterOp),
+    Cancel(Arc<TimerState>),
+}
+
+/// A cheap-to-clone timer capability passed explicitly to tasks.
+///
+/// See the [module level documentation](self) for the driver and reactor integration model.
+#[derive(Clone)]
+pub struct TimerContext {
+    sender: mpsc::UnboundedSender<Operation>,
+    shared: Arc<Shared>,
+}
+
+impl fmt::Debug for TimerContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TimerContext").finish_non_exhaustive()
+    }
+}
+
+impl TimerContext {
+    /// Creates a lazy delay that completes at or after `deadline`.
+    pub fn delay_until(&self, deadline: Instant) -> Delay {
+        self.delay_to(Deadline::At(deadline))
+    }
+
+    /// Creates a lazy delay for `duration` from the context's current observation.
+    ///
+    /// An unrepresentable addition creates a delay that can complete only when its driver closes.
+    pub fn delay(&self, duration: Duration) -> Delay {
+        self.delay_to(Deadline::checked_add(self.now(), duration))
+    }
+
+    fn delay_to(&self, deadline: Deadline) -> Delay {
+        Delay {
+            context: self.clone(),
+            deadline,
+            closed: false,
+            fired_at: None,
+            registered_waker: None,
+            state: None,
+        }
+    }
+
+    fn now(&self) -> Instant {
+        self.shared.observation()
+    }
+
+    fn send(&self, operation: Operation) -> Result<(), Operation> {
+        match self.sender.send(operation) {
+            Ok(()) => {
+                self.shared.wake.notify_after_send();
+                Ok(())
+            }
+            Err(err) => Err(err.into_inner()),
+        }
+    }
+}
+
+/// Reactor-owned timer source.
+///
+/// The driver starts no thread and performs no I/O. A reactor advances it with [`turn`](Self::turn)
+/// and arms its own wake primitive through [`register_wake`](Self::register_wake).
+///
+/// See the [module level documentation](self) for the complete reactor contract.
+pub struct TimerDriver {
+    last_now: Instant,
+    prefer_non_immediate: bool,
+    receiver: Option<mpsc::UnboundedReceiver<Operation>>,
+    shared: Arc<Shared>,
+    wheel: Wheel<Arc<TimerState>>,
+}
+
+impl fmt::Debug for TimerDriver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TimerDriver")
+            .field("last_now", &self.last_now)
+            .finish_non_exhaustive()
+    }
+}
+
+impl TimerDriver {
+    /// Constructs a system-clock driver and its context.
+    pub fn new() -> (Self, TimerContext) {
+        let genesis = Instant::now();
+        Self::with_clock(genesis, ClockMode::System)
+    }
+
+    /// Constructs a deterministic driver whose context clock advances only through
+    /// [`turn`](Self::turn).
+    ///
+    /// This constructor is useful for reactor tests and simulations. It does not read the system
+    /// clock after construction.
+    pub fn new_at(genesis: Instant) -> (Self, TimerContext) {
+        Self::with_clock(genesis, ClockMode::Driven)
+    }
+
+    fn with_clock(genesis: Instant, clock_mode: ClockMode) -> (Self, TimerContext) {
+        let (sender, receiver) = mpsc::unbounded();
+        let shared = Arc::new(Shared {
+            clock_mode,
+            closed: AtomicBool::new(false),
+            observed: Mutex::new(genesis),
+            wake: DriverWake::new(),
+        });
+        let context = TimerContext {
+            sender,
+            shared: shared.clone(),
+        };
+        let driver = Self {
+            last_now: genesis,
+            prefer_non_immediate: true,
+            receiver: Some(receiver),
+            shared,
+            wheel: Wheel::new(genesis),
+        };
+        (driver, context)
+    }
+
+    /// Returns when the driver should next be turned.
+    ///
+    /// Pending operations or due timer work produce the driver's current observation, requesting an
+    /// immediate turn. `None` means there is no finite timer deadline; the driver may be empty or
+    /// contain only delays created by overflowing relative-deadline arithmetic.
+    pub fn next_poll_at(&self) -> Option<Instant> {
+        if self.shared.wake.is_pending() {
+            Some(self.last_now)
+        } else {
+            self.wheel.next_poll_at(self.last_now)
+        }
+    }
+
+    /// Registers a replaceable one-shot wake notification before the reactor parks.
+    ///
+    /// Returns `false` when operations are already pending. In that case the reactor must perform
+    /// a non-blocking I/O poll and call [`turn`](Self::turn) again instead of parking.
+    pub fn register_wake(&self, waker: &Waker) -> bool {
+        self.shared.wake.arm(waker)
+    }
+
+    /// Applies bounded operations and advances timers through `now`.
+    ///
+    /// A release build clamps a backwards `now` to the previous observation.
+    ///
+    /// # Panics
+    ///
+    /// Panics in debug builds when `now` is earlier than the previous observation.
+    pub fn turn(&mut self, now: Instant, budget: TurnBudget) -> TurnResult {
+        debug_assert!(now >= self.last_now, "timer driver cannot move backwards");
+        let now = now.max(self.last_now);
+        self.last_now = now;
+        *self
+            .shared
+            .observed
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = now;
+
+        self.drain_operations(now, budget.max_operations.get());
+
+        let mut entries = 0;
+        // Alternate at entry granularity so neither continuously arriving immediate timers nor
+        // previously registered wheel work can consume every bounded turn.
+        // Once empty, non-immediate work stays empty for this turn: `now` is fixed and subsequent
+        // steps can only remove immediate entries.
+        let mut non_immediate_empty = false;
+        while entries < budget.max_timer_entries.get() {
+            let step = if self.prefer_non_immediate {
+                if non_immediate_empty {
+                    self.wheel.step_immediate()
+                } else {
+                    match self.wheel.step_non_immediate(now) {
+                        Some(step) => Some(step),
+                        None => {
+                            non_immediate_empty = true;
+                            self.wheel.step_immediate()
+                        }
+                    }
+                }
+            } else {
+                self.wheel.step_immediate().or_else(|| {
+                    if non_immediate_empty {
+                        None
+                    } else {
+                        let step = self.wheel.step_non_immediate(now);
+                        non_immediate_empty = step.is_none();
+                        step
+                    }
+                })
+            };
+            let Some(step) = step else {
+                break;
+            };
+            entries += 1;
+            self.prefer_non_immediate = !self.prefer_non_immediate;
+            self.apply_step(step, now);
+        }
+
+        let timer_more = self.wheel.has_due(now);
+        if !timer_more {
+            self.wheel.settle(now);
+        }
+        TurnResult {
+            has_more_work: timer_more || self.shared.wake.is_pending(),
+        }
+    }
+
+    fn apply_step(&mut self, step: Step, now: Instant) {
+        if let Step::Fire(id) = step {
+            self.fire(id, now);
+        }
+    }
+
+    fn drain_operations(&mut self, now: Instant, limit: usize) {
+        let mut processed = 0;
+        while processed < limit {
+            let operation = match self.receiver_mut().try_recv() {
+                Ok(operation) => operation,
+                Err(TryRecvError::Disconnected) => {
+                    self.shared.wake.mark_empty();
+                    break;
+                }
+                Err(TryRecvError::Empty) => {
+                    self.shared.wake.mark_empty();
+                    match self.receiver_mut().try_recv() {
+                        Ok(operation) => {
+                            self.shared.wake.mark_pending();
+                            operation
+                        }
+                        Err(TryRecvError::Disconnected | TryRecvError::Empty) => break,
+                    }
+                }
+            };
+            processed += 1;
+            self.apply_operation(operation, now);
+        }
+    }
+
+    fn apply_operation(&mut self, operation: Operation, now: Instant) {
+        match operation {
+            Operation::Register(operation) => self.register(operation, now),
+            Operation::Cancel(state) => self.cancel(&state),
+        }
+    }
+
+    fn register(&mut self, operation: RegisterOp, now: Instant) {
+        let state = operation
+            .state
+            .as_ref()
+            .expect("register op must own its state")
+            .clone();
+        if state.lifecycle.load(Ordering::Acquire) != STATE_SUBMITTED {
+            return;
+        }
+
+        let id = self.wheel.insert(operation.deadline, now, state.clone());
+        state.slot.store(id, Ordering::Relaxed);
+        if state
+            .lifecycle
+            .compare_exchange(
+                STATE_SUBMITTED,
+                STATE_REGISTERED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_err()
+        {
+            state.slot.store(NO_SLOT, Ordering::Relaxed);
+            self.wheel.remove(id);
+        }
+    }
+
+    fn cancel(&mut self, state: &Arc<TimerState>) {
+        let id = state.slot.load(Ordering::Relaxed);
+        if id == NO_SLOT {
+            return;
+        }
+        let Some(found) = self.wheel.get(id) else {
+            return;
+        };
+        if !Arc::ptr_eq(found, state) {
+            return;
+        }
+        state.slot.store(NO_SLOT, Ordering::Relaxed);
+        self.wheel.remove(id);
+    }
+
+    fn fire(&mut self, id: usize, now: Instant) {
+        let Some(state) = self.wheel.get(id).cloned() else {
+            return;
+        };
+        state
+            .fired_at
+            .set(now)
+            .expect("timer completion observation must be published once");
+        let waker = state.publish_terminal(STATE_REGISTERED, STATE_FIRED);
+        state.slot.store(NO_SLOT, Ordering::Relaxed);
+        self.wheel.remove(id);
+        if let Some(waker) = waker {
+            waker.wake();
+        }
+    }
+
+    fn receiver_mut(&mut self) -> &mut mpsc::UnboundedReceiver<Operation> {
+        self.receiver.as_mut().expect("timer receiver must be live")
+    }
+}
+
+impl Drop for TimerDriver {
+    fn drop(&mut self) {
+        self.shared.closed.store(true, Ordering::Release);
+        self.shared.wake.disarm();
+
+        let mut wakers = Vec::new();
+        for state in self.wheel.drain() {
+            state.slot.store(NO_SLOT, Ordering::Relaxed);
+            if let Some(waker) = state.publish_terminal(STATE_REGISTERED, STATE_CLOSED) {
+                wakers.push(waker);
+            }
+        }
+        for waker in wakers {
+            waker.wake();
+        }
+
+        // Dropping the receiver drops queued RegisterOps, which close timers still in
+        // STATE_SUBMITTED.
+        drop(self.receiver.take());
+    }
+}
+
+/// A lazy future that completes at or after its deadline.
+///
+/// Registration happens on the first poll. Dropping an incomplete delay cancels its registration.
+/// The future returns [`TimerClosed`] if its backing driver is dropped before observing the
+/// deadline, and subsequent polls repeat the same terminal result.
+///
+/// See the [module level documentation](self) for timer resolution and driving requirements.
+#[must_use = "delays do nothing unless polled or awaited"]
+pub struct Delay {
+    context: TimerContext,
+    deadline: Deadline,
+    closed: bool,
+    fired_at: Option<Instant>,
+    registered_waker: Option<Waker>,
+    state: Option<Arc<TimerState>>,
+}
+
+impl fmt::Debug for Delay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Delay")
+            .field("deadline", &self.deadline)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Delay {
+    fn completion_observation(&self) -> Instant {
+        self.fired_at
+            .expect("completed delay must have a completion observation")
+    }
+
+    fn is_elapsed_at(&self, now: Instant) -> bool {
+        self.deadline
+            .as_instant()
+            .is_some_and(|deadline| deadline <= now)
+    }
+
+    fn poll_lifecycle(&mut self, lifecycle: u8) -> Poll<Result<(), TimerClosed>> {
+        match lifecycle {
+            STATE_FIRED => {
+                let state = self.state.take().expect("polled delay must have state");
+                state.waker.clear();
+                self.fired_at = Some(
+                    *state
+                        .fired_at
+                        .get()
+                        .expect("fired delay must have a completion observation"),
+                );
+                self.registered_waker = None;
+                Poll::Ready(Ok(()))
+            }
+            STATE_CLOSED => {
+                let state = self.state.take().expect("polled delay must have state");
+                state.waker.clear();
+                self.closed = true;
+                self.registered_waker = None;
+                Poll::Ready(Err(TimerClosed))
+            }
+            STATE_SUBMITTED | STATE_REGISTERED => Poll::Pending,
+            STATE_CANCELLED => unreachable!(
+                "only Delay::drop writes STATE_CANCELLED, so a live Delay cannot observe it"
+            ),
+            state => panic!("invalid timer state {state}"),
+        }
+    }
+}
+
+impl Future for Delay {
+    type Output = Result<(), TimerClosed>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        if this.fired_at.is_some() {
+            return Poll::Ready(Ok(()));
+        }
+        if this.closed {
+            return Poll::Ready(Err(TimerClosed));
+        }
+        if this.state.is_none() {
+            let now = this.context.now();
+            if this.is_elapsed_at(now) {
+                this.fired_at = Some(now);
+                return Poll::Ready(Ok(()));
+            }
+            if this.context.shared.closed.load(Ordering::Acquire) {
+                this.closed = true;
+                return Poll::Ready(Err(TimerClosed));
+            }
+
+            let state = Arc::new(TimerState::new());
+            state.waker.register_and_load(cx.waker(), &state.lifecycle);
+            this.registered_waker = Some(cx.waker().clone());
+            this.state = Some(state.clone());
+            let operation = Operation::Register(RegisterOp {
+                deadline: this.deadline,
+                state: Some(state),
+            });
+            if let Err(operation) = this.context.send(operation) {
+                let Operation::Register(operation) = operation else {
+                    unreachable!("a failed send must return the submitted operation")
+                };
+                let state = operation.into_state();
+                state.lifecycle.store(STATE_CLOSED, Ordering::Release);
+                return this.poll_lifecycle(STATE_CLOSED);
+            }
+
+            let lifecycle = this
+                .state
+                .as_ref()
+                .expect("submitted delay must have state")
+                .lifecycle
+                .load(Ordering::Acquire);
+            return this.poll_lifecycle(lifecycle);
+        }
+
+        let state = this.state.as_ref().expect("polled delay must have state");
+        let lifecycle = if this
+            .registered_waker
+            .as_ref()
+            .is_some_and(|registered| registered.will_wake(cx.waker()))
+        {
+            // ORDERING: The shared slot still holds an equivalent waker from an earlier poll, so
+            // there is nothing to publish and no fence to pair. A non-terminal lifecycle implies
+            // the slot is still armed: the driver empties it only in `take_after_publish`, which
+            // happens after the terminal transition, and `poll_lifecycle` clears it only on a
+            // terminal state. Skipping the store avoids boxing a waker clone on every repoll.
+            state.lifecycle.load(Ordering::Acquire)
+        } else {
+            let lifecycle = state.waker.register_and_load(cx.waker(), &state.lifecycle);
+            this.registered_waker = Some(cx.waker().clone());
+            lifecycle
+        };
+        this.poll_lifecycle(lifecycle)
+    }
+}
+
+impl Drop for Delay {
+    fn drop(&mut self) {
+        let Some(state) = self.state.as_ref() else {
+            return;
+        };
+        loop {
+            match state.lifecycle.load(Ordering::Acquire) {
+                STATE_SUBMITTED => {
+                    if state
+                        .lifecycle
+                        .compare_exchange(
+                            STATE_SUBMITTED,
+                            STATE_CANCELLED,
+                            Ordering::AcqRel,
+                            Ordering::Acquire,
+                        )
+                        .is_ok()
+                    {
+                        state.waker.clear();
+                        return;
+                    }
+                }
+                STATE_REGISTERED => {
+                    if state
+                        .lifecycle
+                        .compare_exchange(
+                            STATE_REGISTERED,
+                            STATE_CANCELLED,
+                            Ordering::AcqRel,
+                            Ordering::Acquire,
+                        )
+                        .is_ok()
+                    {
+                        state.waker.clear();
+                        let _ = self.context.send(Operation::Cancel(state.clone()));
+                        return;
+                    }
+                }
+                STATE_FIRED | STATE_CANCELLED | STATE_CLOSED => return,
+                state => panic!("invalid timer state {state}"),
+            }
+        }
+    }
+}
+
+/// Why a timed operation did not produce a value.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TimeoutError {
+    /// The deadline was reached first.
+    Elapsed,
+    /// The timer driver was dropped before the deadline was observed.
+    Closed,
+}
+
+impl fmt::Display for TimeoutError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Elapsed => f.write_str("operation timed out"),
+            Self::Closed => f.write_str("timer driver is closed"),
+        }
+    }
+}
+
+impl std::error::Error for TimeoutError {}
+
+/// Runs `future` until it completes or `duration` elapses.
+///
+/// The guarded future wins when both branches become ready in the same poll.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::time::Duration;
+///
+/// use mea::time::TimeoutError;
+/// use mea::time::TimerContext;
+/// use mea::time::timeout;
+///
+/// # async fn example(timer: &TimerContext) -> Result<(), TimeoutError> {
+/// let value = timeout(timer, Duration::from_secs(1), async { 42 }).await?;
+/// assert_eq!(value, 42);
+/// # Ok(())
+/// # }
+/// ```
+pub async fn timeout<F>(
+    timer: &TimerContext,
+    duration: Duration,
+    future: F,
+) -> Result<F::Output, TimeoutError>
+where
+    F: Future,
+{
+    timeout_with_delay(timer.delay(duration), future).await
+}
+
+/// Runs `future` until it completes or `deadline` is reached.
+///
+/// The guarded future wins when both branches become ready in the same poll.
+pub async fn timeout_at<F>(
+    timer: &TimerContext,
+    deadline: Instant,
+    future: F,
+) -> Result<F::Output, TimeoutError>
+where
+    F: Future,
+{
+    timeout_with_delay(timer.delay_until(deadline), future).await
+}
+
+async fn timeout_with_delay<F>(delay: Delay, future: F) -> Result<F::Output, TimeoutError>
+where
+    F: Future,
+{
+    let mut future = std::pin::pin!(future);
+    let mut delay = std::pin::pin!(delay);
+    poll_fn(|cx| {
+        if let Poll::Ready(output) = future.as_mut().poll(cx) {
+            return Poll::Ready(Ok(output));
+        }
+        match delay.as_mut().poll(cx) {
+            Poll::Ready(Ok(())) => Poll::Ready(Err(TimeoutError::Elapsed)),
+            Poll::Ready(Err(TimerClosed)) => Poll::Ready(Err(TimeoutError::Closed)),
+            Poll::Pending => Poll::Pending,
+        }
+    })
+    .await
+}
+
+/// How an [`Interval`] responds when one or more ticks were missed.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum MissedTickBehavior {
+    /// Preserve every scheduled deadline and catch up with immediately ready ticks.
+    #[default]
+    Burst,
+    /// Schedule the next tick one period after the completed tick was observed.
+    Delay,
+    /// Stay on the original grid while discarding deadlines at or before the observation.
+    Skip,
+}
+
+/// A periodic timer built from sequential [`Delay`] futures.
+///
+/// See the [module level documentation](self) for timer resolution and driving requirements.
+#[derive(Debug)]
+#[must_use = "an interval advances only when tick is awaited"]
+pub struct Interval {
+    behavior: MissedTickBehavior,
+    deadline: Deadline,
+    delay: Delay,
+    period: Duration,
+    timer: TimerContext,
+}
+
+impl Interval {
+    /// Waits for and consumes the next tick, returning its scheduled deadline.
+    ///
+    /// Cancelling this future before completion does not consume the tick.
+    pub async fn tick(&mut self) -> Result<Instant, TimerClosed> {
+        (&mut self.delay).await?;
+        let observation = self.delay.completion_observation();
+        let scheduled = self
+            .deadline
+            .as_instant()
+            .expect("a never deadline cannot complete successfully");
+        self.deadline = self.next_deadline(scheduled, observation);
+        self.delay = self.timer.delay_to(self.deadline);
+        Ok(scheduled)
+    }
+
+    /// Returns the current missed-tick behavior.
+    pub const fn missed_tick_behavior(&self) -> MissedTickBehavior {
+        self.behavior
+    }
+
+    /// Changes the missed-tick behavior used after the next completed tick.
+    pub fn set_missed_tick_behavior(&mut self, behavior: MissedTickBehavior) {
+        self.behavior = behavior;
+    }
+
+    fn next_deadline(&self, scheduled: Instant, observation: Instant) -> Deadline {
+        match self.behavior {
+            MissedTickBehavior::Burst => Deadline::checked_add(scheduled, self.period),
+            MissedTickBehavior::Delay => Deadline::checked_add(observation, self.period),
+            MissedTickBehavior::Skip => skip_deadline(scheduled, self.period, observation),
+        }
+    }
+}
+
+/// Creates an interval with an immediate first tick.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::time::Duration;
+///
+/// use mea::time::TimerClosed;
+/// use mea::time::TimerContext;
+/// use mea::time::interval;
+///
+/// # async fn example(timer: &TimerContext) -> Result<(), TimerClosed> {
+/// let mut ticks = interval(timer, Duration::from_secs(1));
+/// let scheduled_at = ticks.tick().await?;
+/// # let _ = scheduled_at;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # Panics
+///
+/// Panics when `period` is zero.
+pub fn interval(timer: &TimerContext, period: Duration) -> Interval {
+    interval_from_deadline(timer, Deadline::At(timer.now()), period)
+}
+
+/// Creates an interval whose first tick is scheduled at `start`.
+///
+/// # Panics
+///
+/// Panics when `period` is zero.
+pub fn interval_at(timer: &TimerContext, start: Instant, period: Duration) -> Interval {
+    interval_from_deadline(timer, Deadline::At(start), period)
+}
+
+fn interval_from_deadline(timer: &TimerContext, deadline: Deadline, period: Duration) -> Interval {
+    assert!(!period.is_zero(), "interval period must be non-zero");
+    Interval {
+        behavior: MissedTickBehavior::Burst,
+        deadline,
+        delay: timer.delay_to(deadline),
+        period,
+        timer: timer.clone(),
+    }
+}
+
+fn skip_deadline(scheduled: Instant, period: Duration, observation: Instant) -> Deadline {
+    let Some(elapsed) = observation.checked_duration_since(scheduled) else {
+        return Deadline::checked_add(scheduled, period);
+    };
+    let elapsed_nanos = elapsed.as_nanos();
+    let period_nanos = period.as_nanos();
+    let periods = elapsed_nanos / period_nanos + 1;
+    let Some(total_nanos) = period_nanos.checked_mul(periods) else {
+        return Deadline::Never;
+    };
+    let seconds = total_nanos / 1_000_000_000;
+    let Ok(seconds) = u64::try_from(seconds) else {
+        return Deadline::Never;
+    };
+    let nanos = (total_nanos % 1_000_000_000) as u32;
+    Deadline::checked_add(scheduled, Duration::new(seconds, nanos))
+}
+
+/// Repeatedly runs `task`, waiting `delay` after each completion.
+///
+/// `None` starts the first task immediately; `Some(duration)` delays the first invocation.
+/// This future otherwise runs until it is dropped, returning [`TimerClosed`] only if the driver
+/// closes.
+///
+/// # Panics
+///
+/// Panics when `delay` is zero.
+pub async fn schedule_with_fixed_delay<F>(
+    timer: &TimerContext,
+    initial_delay: Option<Duration>,
+    delay: Duration,
+    mut task: F,
+) -> Result<(), TimerClosed>
+where
+    F: AsyncFnMut(),
+{
+    assert!(!delay.is_zero(), "fixed delay must be non-zero");
+    if let Some(initial_delay) = initial_delay {
+        timer.delay(initial_delay).await?;
+    }
+    loop {
+        task().await;
+        timer.delay(delay).await?;
+    }
+}
+
+/// Repeatedly runs `task` on a fixed grid, skipping missed invocations without overlap.
+///
+/// `None` starts the first task immediately; `Some(duration)` delays the first invocation.
+/// This future otherwise runs until it is dropped, returning [`TimerClosed`] only if the driver
+/// closes.
+///
+/// A task that outruns its period does not cause the following invocations to run back to back.
+/// The next deadline is the first grid point strictly after the task completes, so the schedule
+/// stays aligned to the original grid and merely drops the invocations it missed.
+///
+/// # Panics
+///
+/// Panics when `period` is zero.
+pub async fn schedule_at_fixed_rate<F>(
+    timer: &TimerContext,
+    initial_delay: Option<Duration>,
+    period: Duration,
+    mut task: F,
+) -> Result<(), TimerClosed>
+where
+    F: AsyncFnMut(),
+{
+    assert!(!period.is_zero(), "fixed rate must be non-zero");
+    let now = timer.now();
+    let mut scheduled = match initial_delay {
+        Some(delay) => Deadline::checked_add(now, delay),
+        None => Deadline::At(now),
+    };
+    loop {
+        timer.delay_to(scheduled).await?;
+        let completed = scheduled
+            .as_instant()
+            .expect("a never deadline cannot complete successfully");
+        task().await;
+        // The observation is read *after* the task returns. Deriving the next grid point from
+        // the tick's own completion instead would let an overrunning task collapse the schedule
+        // into back-to-back invocations, because every subsequent deadline would already be in
+        // the past by the time it was awaited.
+        scheduled = skip_deadline(completed, period, timer.now());
+    }
+}
+
+/// Repeatedly runs `task`, using each returned instant as the next deadline.
+///
+/// `None` starts the first task immediately; `Some(duration)` delays the first invocation.
+/// Returning an elapsed instant repeatedly creates an intentionally busy loop.
+/// This future otherwise runs until it is dropped, returning [`TimerClosed`] only if the driver
+/// closes.
+pub async fn schedule_with_arbitrary_delay<F>(
+    timer: &TimerContext,
+    initial_delay: Option<Duration>,
+    mut task: F,
+) -> Result<(), TimerClosed>
+where
+    F: AsyncFnMut() -> Instant,
+{
+    if let Some(initial_delay) = initial_delay {
+        timer.delay(initial_delay).await?;
+    }
+    loop {
+        let next = task().await;
+        timer.delay_until(next).await?;
+    }
+}

--- a/mea/src/time/tests.rs
+++ b/mea/src/time/tests.rs
@@ -1,0 +1,1084 @@
+// Copyright 2024 tison <wander4096@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+use std::future::pending;
+use std::future::ready;
+use std::num::NonZeroUsize;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::Barrier;
+use std::sync::Mutex;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::task::Context;
+use std::task::Poll;
+use std::task::Wake;
+use std::task::Waker;
+use std::time::Duration;
+use std::time::Instant;
+
+use super::*;
+
+fn poll<T>(future: Pin<&mut impl Future<Output = T>>) -> Poll<T> {
+    let waker = Waker::noop();
+    poll_with_waker(future, waker)
+}
+
+fn poll_with_waker<T>(future: Pin<&mut impl Future<Output = T>>, waker: &Waker) -> Poll<T> {
+    let mut cx = Context::from_waker(waker);
+    future.poll(&mut cx)
+}
+
+fn budget() -> TurnBudget {
+    TurnBudget::new(
+        NonZeroUsize::new(64).unwrap(),
+        NonZeroUsize::new(64).unwrap(),
+    )
+}
+
+fn tiny_budget() -> TurnBudget {
+    TurnBudget::new(NonZeroUsize::new(2).unwrap(), NonZeroUsize::new(1).unwrap())
+}
+
+fn drive(driver: &mut TimerDriver, now: Instant) {
+    let _ = driver.turn(now, budget());
+}
+
+fn drive_with_tiny_budget(driver: &mut TimerDriver, now: Instant) {
+    let _ = driver.turn(now, tiny_budget());
+}
+
+fn assert_schedule_waits_for_initial_delay(
+    driver: &mut TimerDriver,
+    genesis: Instant,
+    mut schedule: Pin<&mut impl Future<Output = Result<(), TimerClosed>>>,
+    count: &AtomicUsize,
+) {
+    assert!(poll(schedule.as_mut()).is_pending());
+    assert_eq!(count.load(Ordering::Relaxed), 0);
+    drive(driver, genesis);
+    drive(driver, genesis + Duration::from_millis(4));
+    assert!(poll(schedule.as_mut()).is_pending());
+    assert_eq!(count.load(Ordering::Relaxed), 0);
+    drive(driver, genesis + Duration::from_millis(5));
+    assert!(poll(schedule.as_mut()).is_pending());
+    assert_eq!(count.load(Ordering::Relaxed), 1);
+}
+
+#[derive(Default)]
+struct WakeCount(AtomicUsize);
+
+impl Wake for WakeCount {
+    fn wake(self: Arc<Self>) {
+        self.0.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+#[test]
+fn default_turn_budget_matches_documented_limits() {
+    let budget = TurnBudget::default();
+    assert_eq!(budget.max_operations().get(), 1_024);
+    assert_eq!(budget.max_timer_entries().get(), 4_096);
+}
+
+#[test]
+fn system_clock_context_uses_wall_clock_and_published_observation() {
+    let (mut driver, timer) = TimerDriver::new();
+    let duration = Duration::from_millis(10);
+
+    let before = Instant::now();
+    let wall_clock_delay = timer.delay(duration);
+    assert!(
+        wall_clock_delay.deadline.as_instant().unwrap() >= before.checked_add(duration).unwrap()
+    );
+
+    let published = Instant::now()
+        .checked_add(Duration::from_secs(86_400))
+        .unwrap();
+    drive(&mut driver, published);
+    let published_delay = timer.delay(duration);
+    assert_eq!(
+        published_delay.deadline,
+        Deadline::At(published.checked_add(duration).unwrap())
+    );
+}
+
+#[test]
+fn next_poll_at_reports_pending_operations_and_the_earliest_deadline() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    let later_deadline = genesis + Duration::from_millis(20);
+    let earlier_deadline = genesis + Duration::from_millis(10);
+
+    let mut later = Box::pin(timer.delay_until(later_deadline));
+    assert!(poll(later.as_mut()).is_pending());
+    assert_eq!(driver.next_poll_at(), Some(genesis));
+    drive(&mut driver, genesis);
+    assert_eq!(driver.next_poll_at(), Some(later_deadline));
+
+    let mut earlier = Box::pin(timer.delay_until(earlier_deadline));
+    assert!(poll(earlier.as_mut()).is_pending());
+    assert_eq!(driver.next_poll_at(), Some(genesis));
+    drive(&mut driver, genesis);
+    assert_eq!(driver.next_poll_at(), Some(earlier_deadline));
+}
+
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "timer driver cannot move backwards")]
+fn turn_rejects_a_backwards_clock_in_debug_builds() {
+    let genesis = Instant::now();
+    let (mut driver, _timer) = TimerDriver::new_at(genesis);
+    drive(&mut driver, genesis + Duration::from_millis(1));
+    drive(&mut driver, genesis);
+}
+
+#[test]
+fn dropping_driver_releases_its_registered_reactor_waker() {
+    let genesis = Instant::now();
+    let (driver, timer) = TimerDriver::new_at(genesis);
+    let counter = Arc::new(WakeCount::default());
+    let waker = Waker::from(counter.clone());
+
+    assert!(driver.register_wake(&waker));
+    drop(waker);
+    assert_eq!(Arc::strong_count(&counter), 2);
+
+    drop(driver);
+    assert_eq!(Arc::strong_count(&counter), 1);
+    drop(timer);
+}
+
+#[test]
+fn completed_delay_releases_its_registered_waker() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    let counter = Arc::new(WakeCount::default());
+    let waker = Waker::from(counter.clone());
+    let mut delay = Box::pin(timer.delay(Duration::from_millis(1)));
+
+    assert!(poll_with_waker(delay.as_mut(), &waker).is_pending());
+    drive(&mut driver, genesis);
+    drive(&mut driver, genesis + Duration::from_millis(1));
+    assert_eq!(poll_with_waker(delay.as_mut(), &waker), Poll::Ready(Ok(())));
+    assert!(delay.as_ref().get_ref().state.is_none());
+
+    drop(waker);
+    assert_eq!(Arc::strong_count(&counter), 1);
+    assert_eq!(poll(delay.as_mut()), Poll::Ready(Ok(())));
+}
+
+#[test]
+fn cancelled_delays_release_wakers_before_the_driver_drains() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+
+    let submitted_counter = Arc::new(WakeCount::default());
+    let submitted_waker = Waker::from(submitted_counter.clone());
+    let mut submitted = Box::pin(timer.delay(Duration::from_secs(1)));
+    assert!(poll_with_waker(submitted.as_mut(), &submitted_waker).is_pending());
+    drop(submitted_waker);
+    drop(submitted);
+    assert_eq!(Arc::strong_count(&submitted_counter), 1);
+
+    drive(&mut driver, genesis);
+
+    let registered_counter = Arc::new(WakeCount::default());
+    let registered_waker = Waker::from(registered_counter.clone());
+    let mut registered = Box::pin(timer.delay(Duration::from_secs(1)));
+    assert!(poll_with_waker(registered.as_mut(), &registered_waker).is_pending());
+    drive(&mut driver, genesis);
+    drop(registered_waker);
+    drop(registered);
+    assert_eq!(Arc::strong_count(&registered_counter), 1);
+
+    drive(&mut driver, genesis);
+    assert_eq!(driver.wheel.len(), 0);
+}
+
+#[test]
+fn delay_is_lazy_and_uses_driven_time() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    let mut delay = std::pin::pin!(timer.delay(Duration::from_millis(10)));
+
+    assert_eq!(driver.wheel.len(), 0);
+    assert!(poll(delay.as_mut()).is_pending());
+    assert_eq!(driver.wheel.len(), 0);
+
+    assert!(!driver.turn(genesis, budget()).has_more_work());
+    assert_eq!(driver.wheel.len(), 1);
+    assert!(poll(delay.as_mut()).is_pending());
+
+    drive(&mut driver, genesis + Duration::from_millis(9));
+    assert!(poll(delay.as_mut()).is_pending());
+    drive(&mut driver, genesis + Duration::from_millis(10));
+    assert_eq!(poll(delay.as_mut()), Poll::Ready(Ok(())));
+}
+
+#[test]
+fn dropping_driver_closes_registered_delay() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    let mut delay = std::pin::pin!(timer.delay(Duration::from_secs(1)));
+
+    assert!(poll(delay.as_mut()).is_pending());
+    drive(&mut driver, genesis);
+    drop(driver);
+    assert_eq!(poll(delay.as_mut()), Poll::Ready(Err(TimerClosed)));
+    assert!(delay.as_ref().get_ref().state.is_none());
+    assert_eq!(poll(delay.as_mut()), Poll::Ready(Err(TimerClosed)));
+}
+
+#[test]
+fn dropping_driver_closes_queued_delay() {
+    let genesis = Instant::now();
+    let (driver, timer) = TimerDriver::new_at(genesis);
+    let mut delay = std::pin::pin!(timer.delay(Duration::from_secs(1)));
+
+    assert!(poll(delay.as_mut()).is_pending());
+    drop(driver);
+    assert_eq!(poll(delay.as_mut()), Poll::Ready(Err(TimerClosed)));
+    assert!(delay.as_ref().get_ref().state.is_none());
+    assert_eq!(poll(delay.as_mut()), Poll::Ready(Err(TimerClosed)));
+}
+
+#[test]
+fn failed_registration_send_returns_closed_without_self_wake() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    drop(driver.receiver.take());
+    let counter = Arc::new(WakeCount::default());
+    let waker = Waker::from(counter.clone());
+    let mut delay = Box::pin(timer.delay(Duration::from_secs(1)));
+
+    assert_eq!(
+        poll_with_waker(delay.as_mut(), &waker),
+        Poll::Ready(Err(TimerClosed))
+    );
+    assert_eq!(counter.0.load(Ordering::Relaxed), 0);
+    assert!(delay.as_ref().get_ref().state.is_none());
+    assert_eq!(poll(delay.as_mut()), Poll::Ready(Err(TimerClosed)));
+}
+
+#[test]
+fn fresh_delay_after_close_is_synchronously_closed_and_fused() {
+    let genesis = Instant::now();
+    let (driver, timer) = TimerDriver::new_at(genesis);
+    drop(driver);
+    let mut delay = std::pin::pin!(timer.delay_until(genesis + Duration::from_secs(1)));
+
+    assert_eq!(poll(delay.as_mut()), Poll::Ready(Err(TimerClosed)));
+    assert_eq!(poll(delay.as_mut()), Poll::Ready(Err(TimerClosed)));
+}
+
+#[test]
+fn elapsed_deadline_wins_over_closed_driver() {
+    let genesis = Instant::now();
+    let (driver, timer) = TimerDriver::new_at(genesis);
+    drop(driver);
+    let mut delay = std::pin::pin!(timer.delay_until(genesis));
+
+    assert_eq!(poll(delay.as_mut()), Poll::Ready(Ok(())));
+}
+
+#[test]
+fn cancellation_before_and_after_registration_reclaims_entries() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+
+    let mut submitted = Box::pin(timer.delay(Duration::from_secs(1)));
+    assert!(poll(submitted.as_mut()).is_pending());
+    drop(submitted);
+    drive(&mut driver, genesis);
+    assert_eq!(driver.wheel.len(), 0);
+
+    let mut registered = Box::pin(timer.delay(Duration::from_secs(1)));
+    assert!(poll(registered.as_mut()).is_pending());
+    drive(&mut driver, genesis);
+    assert_eq!(driver.wheel.len(), 1);
+    drop(registered);
+    drive(&mut driver, genesis);
+    assert_eq!(driver.wheel.len(), 0);
+}
+
+#[test]
+fn operation_and_entry_budgets_bound_each_turn() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    let mut delays: Vec<_> = (0..5)
+        .map(|_| Box::pin(timer.delay_until(genesis + Duration::from_millis(1))))
+        .collect();
+    for delay in &mut delays {
+        assert!(poll(delay.as_mut()).is_pending());
+    }
+
+    assert!(driver.turn(genesis, tiny_budget()).has_more_work());
+    assert_eq!(driver.wheel.len(), 2);
+    assert!(driver.turn(genesis, tiny_budget()).has_more_work());
+    assert_eq!(driver.wheel.len(), 4);
+    drive_with_tiny_budget(&mut driver, genesis);
+    assert_eq!(driver.wheel.len(), 5);
+
+    let due = genesis + Duration::from_millis(1);
+    for expected in 1..=5 {
+        let result = driver.turn(due, tiny_budget());
+        let mut now_completed = 0;
+        for delay in &mut delays {
+            if poll(delay.as_mut()).is_ready() {
+                now_completed += 1;
+            }
+        }
+        assert_eq!(now_completed, expected);
+        assert_eq!(result.has_more_work(), expected != 5);
+    }
+}
+
+#[test]
+fn immediate_and_wheel_timers_both_progress_under_continuous_registrations() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    let mut existing = Box::pin(timer.delay_until(genesis + Duration::from_millis(1)));
+    assert!(poll(existing.as_mut()).is_pending());
+    drive(&mut driver, genesis);
+
+    let mut immediate = Vec::new();
+    for millis in 1..=2 {
+        let now = genesis + Duration::from_millis(millis);
+        for _ in 0..2 {
+            let mut delay = Box::pin(timer.delay_until(now));
+            assert!(poll(delay.as_mut()).is_pending());
+            immediate.push(delay);
+        }
+        let _ = driver.turn(now, tiny_budget());
+    }
+
+    assert_eq!(poll(existing.as_mut()), Poll::Ready(Ok(())));
+    assert!(
+        immediate
+            .iter_mut()
+            .any(|delay| poll(delay.as_mut()).is_ready())
+    );
+}
+
+#[test]
+fn immediate_and_wheel_timers_share_the_entry_budget() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    let due = genesis + Duration::from_millis(1);
+    let mut wheel: Vec<_> = (0..8).map(|_| Box::pin(timer.delay_until(due))).collect();
+    for delay in &mut wheel {
+        assert!(poll(delay.as_mut()).is_pending());
+    }
+    drive(&mut driver, genesis);
+
+    let mut immediate: Vec<_> = (0..8).map(|_| Box::pin(timer.delay_until(due))).collect();
+    for delay in &mut immediate {
+        assert!(poll(delay.as_mut()).is_pending());
+    }
+
+    let budget = TurnBudget::new(
+        NonZeroUsize::new(16).unwrap(),
+        NonZeroUsize::new(6).unwrap(),
+    );
+    assert!(driver.turn(due, budget).has_more_work());
+    assert_eq!(
+        wheel
+            .iter_mut()
+            .map(|delay| poll(delay.as_mut()).is_ready())
+            .filter(|ready| *ready)
+            .count(),
+        3
+    );
+    assert_eq!(
+        immediate
+            .iter_mut()
+            .map(|delay| poll(delay.as_mut()).is_ready())
+            .filter(|ready| *ready)
+            .count(),
+        3
+    );
+}
+
+#[test]
+fn operation_wake_is_coalesced_and_renewable() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    drive(&mut driver, genesis);
+    let counter = Arc::new(WakeCount::default());
+    let waker = Waker::from(counter.clone());
+    assert!(driver.register_wake(&waker));
+
+    let mut first = Box::pin(timer.delay(Duration::from_secs(1)));
+    let mut second = Box::pin(timer.delay(Duration::from_secs(2)));
+    assert!(poll(first.as_mut()).is_pending());
+    assert!(poll(second.as_mut()).is_pending());
+    assert_eq!(counter.0.load(Ordering::Relaxed), 1);
+    assert!(!driver.register_wake(&waker));
+
+    drive(&mut driver, genesis);
+    assert!(driver.register_wake(&waker));
+    drop(first);
+    assert_eq!(counter.0.load(Ordering::Relaxed), 2);
+    drive(&mut driver, genesis);
+    assert!(driver.register_wake(&waker));
+}
+
+#[test]
+fn submillisecond_deadline_never_fires_early() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    let deadline = genesis + Duration::from_micros(500);
+    let mut delay = Box::pin(timer.delay_until(deadline));
+
+    assert!(poll(delay.as_mut()).is_pending());
+    drive(&mut driver, genesis);
+    drive(&mut driver, genesis + Duration::from_micros(999));
+    assert!(poll(delay.as_mut()).is_pending());
+    drive(&mut driver, genesis + Duration::from_millis(1));
+    assert_eq!(poll(delay.as_mut()), Poll::Ready(Ok(())));
+}
+
+#[test]
+fn driven_relative_delay_keeps_submillisecond_observation() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    drive(&mut driver, genesis + Duration::from_micros(500));
+    let mut delay = Box::pin(timer.delay(Duration::from_millis(1)));
+
+    assert!(poll(delay.as_mut()).is_pending());
+    drive(&mut driver, genesis + Duration::from_millis(1));
+    assert!(poll(delay.as_mut()).is_pending());
+    drive(&mut driver, genesis + Duration::from_millis(2));
+    assert_eq!(poll(delay.as_mut()), Poll::Ready(Ok(())));
+}
+
+#[test]
+fn timeout_prefers_guarded_future_on_tie() {
+    let genesis = Instant::now();
+    let (_driver, timer) = TimerDriver::new_at(genesis);
+    assert_eq!(
+        pollster::block_on(timeout_at(&timer, genesis, ready(7))),
+        Ok(7)
+    );
+}
+
+#[test]
+fn timeout_distinguishes_elapsed_and_closed() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    let mut elapsed = Box::pin(timeout_at(
+        &timer,
+        genesis + Duration::from_millis(1),
+        pending::<()>(),
+    ));
+    assert!(poll(elapsed.as_mut()).is_pending());
+    drive(&mut driver, genesis + Duration::from_millis(1));
+    assert_eq!(
+        poll(elapsed.as_mut()),
+        Poll::Ready(Err(TimeoutError::Elapsed))
+    );
+    drop(elapsed);
+
+    let mut closed = Box::pin(timeout(&timer, Duration::from_secs(1), pending::<()>()));
+    assert!(poll(closed.as_mut()).is_pending());
+    drop(driver);
+    assert_eq!(
+        poll(closed.as_mut()),
+        Poll::Ready(Err(TimeoutError::Closed))
+    );
+}
+
+#[test]
+fn never_deadline_only_completes_on_close() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    let mut delay = Box::pin(timer.delay(Duration::MAX));
+
+    assert!(poll(delay.as_mut()).is_pending());
+    drive(&mut driver, genesis + Duration::from_secs(10));
+    assert!(poll(delay.as_mut()).is_pending());
+    assert_eq!(driver.next_poll_at(), None);
+    drop(driver);
+    assert_eq!(poll(delay.as_mut()), Poll::Ready(Err(TimerClosed)));
+}
+
+#[test]
+fn interval_missed_tick_behaviors_have_distinct_schedules() {
+    let genesis = Instant::now();
+    for (behavior, expected) in [
+        (MissedTickBehavior::Burst, 20),
+        (MissedTickBehavior::Delay, 45),
+        (MissedTickBehavior::Skip, 40),
+    ] {
+        let (mut driver, timer) = TimerDriver::new_at(genesis);
+        let mut interval = interval_at(
+            &timer,
+            genesis + Duration::from_millis(10),
+            Duration::from_millis(10),
+        );
+        interval.set_missed_tick_behavior(behavior);
+        assert_eq!(interval.missed_tick_behavior(), behavior);
+        let mut tick = Box::pin(interval.tick());
+        assert!(poll(tick.as_mut()).is_pending());
+        drive(&mut driver, genesis + Duration::from_millis(35));
+        assert_eq!(
+            poll(tick.as_mut()),
+            Poll::Ready(Ok(genesis + Duration::from_millis(10)))
+        );
+        drop(tick);
+        assert_eq!(
+            interval.deadline,
+            Deadline::At(genesis + Duration::from_millis(expected))
+        );
+    }
+}
+
+#[test]
+fn interval_has_an_immediate_first_tick() {
+    let genesis = Instant::now();
+    let (_driver, timer) = TimerDriver::new_at(genesis);
+    let mut interval = interval(&timer, Duration::from_millis(10));
+
+    assert_eq!(interval.missed_tick_behavior(), MissedTickBehavior::Burst);
+    assert_eq!(pollster::block_on(interval.tick()), Ok(genesis));
+}
+
+#[test]
+#[should_panic(expected = "interval period must be non-zero")]
+fn interval_rejects_a_zero_period() {
+    let genesis = Instant::now();
+    let (_driver, timer) = TimerDriver::new_at(genesis);
+    let _ = interval(&timer, Duration::ZERO);
+}
+
+#[test]
+#[should_panic(expected = "interval period must be non-zero")]
+fn interval_at_rejects_a_zero_period() {
+    let genesis = Instant::now();
+    let (_driver, timer) = TimerDriver::new_at(genesis);
+    let _ = interval_at(&timer, genesis, Duration::ZERO);
+}
+
+#[test]
+fn skip_does_not_discard_a_future_grid_point_within_the_same_tick() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    let mut interval = interval_at(
+        &timer,
+        genesis + Duration::from_millis(10),
+        Duration::from_millis(10),
+    );
+    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    let mut tick = Box::pin(interval.tick());
+    assert!(poll(tick.as_mut()).is_pending());
+
+    drive(&mut driver, genesis + Duration::from_micros(39_900));
+    assert_eq!(
+        poll(tick.as_mut()),
+        Poll::Ready(Ok(genesis + Duration::from_millis(10)))
+    );
+    drop(tick);
+    assert_eq!(
+        interval.deadline,
+        Deadline::At(genesis + Duration::from_millis(40))
+    );
+}
+
+#[test]
+fn interval_tick_is_cancel_safe() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    let mut interval = interval_at(
+        &timer,
+        genesis + Duration::from_millis(10),
+        Duration::from_millis(10),
+    );
+
+    let mut first_attempt = Box::pin(interval.tick());
+    assert!(poll(first_attempt.as_mut()).is_pending());
+    drop(first_attempt);
+    drive(&mut driver, genesis + Duration::from_millis(10));
+    assert_eq!(
+        pollster::block_on(interval.tick()),
+        Ok(genesis + Duration::from_millis(10))
+    );
+}
+
+#[test]
+fn scheduling_futures_do_not_spawn_and_propagate_close() {
+    let genesis = Instant::now();
+
+    let (driver, timer) = TimerDriver::new_at(genesis);
+    let fixed_delay_count = Arc::new(AtomicUsize::new(0));
+    let count = fixed_delay_count.clone();
+    let mut fixed_delay = Box::pin(schedule_with_fixed_delay(
+        &timer,
+        None,
+        Duration::from_millis(1),
+        async move || {
+            count.fetch_add(1, Ordering::Relaxed);
+        },
+    ));
+    assert!(poll(fixed_delay.as_mut()).is_pending());
+    assert_eq!(fixed_delay_count.load(Ordering::Relaxed), 1);
+    drop(driver);
+    assert_eq!(poll(fixed_delay.as_mut()), Poll::Ready(Err(TimerClosed)));
+
+    let (driver, timer) = TimerDriver::new_at(genesis);
+    let fixed_rate_count = Arc::new(AtomicUsize::new(0));
+    let count = fixed_rate_count.clone();
+    let mut fixed_rate = Box::pin(schedule_at_fixed_rate(
+        &timer,
+        None,
+        Duration::from_millis(1),
+        async move || {
+            count.fetch_add(1, Ordering::Relaxed);
+        },
+    ));
+    assert!(poll(fixed_rate.as_mut()).is_pending());
+    assert_eq!(fixed_rate_count.load(Ordering::Relaxed), 1);
+    drop(driver);
+    assert_eq!(poll(fixed_rate.as_mut()), Poll::Ready(Err(TimerClosed)));
+
+    let (driver, timer) = TimerDriver::new_at(genesis);
+    let arbitrary_count = Arc::new(AtomicUsize::new(0));
+    let count = arbitrary_count.clone();
+    let mut arbitrary = Box::pin(schedule_with_arbitrary_delay(
+        &timer,
+        None,
+        async move || {
+            count.fetch_add(1, Ordering::Relaxed);
+            genesis + Duration::from_millis(1)
+        },
+    ));
+    assert!(poll(arbitrary.as_mut()).is_pending());
+    assert_eq!(arbitrary_count.load(Ordering::Relaxed), 1);
+    drop(driver);
+    assert_eq!(poll(arbitrary.as_mut()), Poll::Ready(Err(TimerClosed)));
+}
+
+#[test]
+fn scheduling_futures_honor_their_initial_delay() {
+    let genesis = Instant::now();
+    let initial_delay = Some(Duration::from_millis(5));
+
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    let count = Arc::new(AtomicUsize::new(0));
+    let observed = count.clone();
+    let mut schedule = Box::pin(schedule_with_fixed_delay(
+        &timer,
+        initial_delay,
+        Duration::from_millis(1),
+        async move || {
+            observed.fetch_add(1, Ordering::Relaxed);
+        },
+    ));
+    assert_schedule_waits_for_initial_delay(&mut driver, genesis, schedule.as_mut(), &count);
+
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    let count = Arc::new(AtomicUsize::new(0));
+    let observed = count.clone();
+    let mut schedule = Box::pin(schedule_at_fixed_rate(
+        &timer,
+        initial_delay,
+        Duration::from_millis(1),
+        async move || {
+            observed.fetch_add(1, Ordering::Relaxed);
+        },
+    ));
+    assert_schedule_waits_for_initial_delay(&mut driver, genesis, schedule.as_mut(), &count);
+
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    let count = Arc::new(AtomicUsize::new(0));
+    let observed = count.clone();
+    let mut schedule = Box::pin(schedule_with_arbitrary_delay(
+        &timer,
+        initial_delay,
+        async move || {
+            observed.fetch_add(1, Ordering::Relaxed);
+            genesis + Duration::from_millis(6)
+        },
+    ));
+    assert_schedule_waits_for_initial_delay(&mut driver, genesis, schedule.as_mut(), &count);
+}
+
+#[test]
+#[should_panic(expected = "fixed delay must be non-zero")]
+fn fixed_delay_schedule_rejects_a_zero_delay() {
+    let genesis = Instant::now();
+    let (_driver, timer) = TimerDriver::new_at(genesis);
+    let _ = pollster::block_on(schedule_with_fixed_delay(
+        &timer,
+        None,
+        Duration::ZERO,
+        async || {},
+    ));
+}
+
+#[test]
+#[should_panic(expected = "fixed rate must be non-zero")]
+fn fixed_rate_schedule_rejects_a_zero_period() {
+    let genesis = Instant::now();
+    let (_driver, timer) = TimerDriver::new_at(genesis);
+    let _ = pollster::block_on(schedule_at_fixed_rate(
+        &timer,
+        None,
+        Duration::ZERO,
+        async || {},
+    ));
+}
+
+#[test]
+fn concurrent_arm_and_first_operation_never_both_miss() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+
+    for _ in 0..1_000 {
+        drive(&mut driver, genesis);
+        let barrier = Arc::new(Barrier::new(2));
+        let sender_barrier = barrier.clone();
+        let sender_timer = timer.clone();
+        let sender = std::thread::spawn(move || {
+            let mut delay = Box::pin(sender_timer.delay(Duration::from_secs(1)));
+            sender_barrier.wait();
+            assert!(poll(delay.as_mut()).is_pending());
+            delay
+        });
+
+        let counter = Arc::new(WakeCount::default());
+        let waker = Waker::from(counter.clone());
+        barrier.wait();
+        let armed = driver.register_wake(&waker);
+        let delay = sender.join().unwrap();
+        assert!(
+            !armed || counter.0.load(Ordering::Relaxed) > 0,
+            "driver armed successfully but the first producer missed its wake slot"
+        );
+
+        drive(&mut driver, genesis);
+        drop(delay);
+        drive(&mut driver, genesis);
+        assert_eq!(driver.wheel.len(), 0);
+    }
+}
+
+#[test]
+fn concurrent_delay_registration_and_fire_never_lose_wake() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    let mut now = genesis;
+
+    for _ in 0..1_000 {
+        let deadline = now + Duration::from_millis(1);
+        let mut delay = Box::pin(timer.delay_until(deadline));
+        assert!(poll(delay.as_mut()).is_pending());
+        drive(&mut driver, now);
+
+        let barrier = Arc::new(Barrier::new(2));
+        let poll_barrier = barrier.clone();
+        let counter = Arc::new(WakeCount::default());
+        let poll_counter = counter.clone();
+        let polling = std::thread::spawn(move || {
+            let waker = Waker::from(poll_counter.clone());
+            poll_barrier.wait();
+            let result = poll_with_waker(delay.as_mut(), &waker);
+            (delay, result, poll_counter)
+        });
+
+        barrier.wait();
+        drive(&mut driver, deadline);
+        let (mut delay, result, counter) = polling.join().unwrap();
+        if result.is_pending() {
+            assert!(
+                counter.0.load(Ordering::Relaxed) > 0,
+                "Delay returned Pending while the terminal publisher missed its waker"
+            );
+        }
+        assert_eq!(poll(delay.as_mut()), Poll::Ready(Ok(())));
+        now = deadline;
+    }
+}
+
+#[test]
+fn concurrent_cancel_and_fire_reclaim_exactly_once() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    let mut now = genesis;
+
+    for _ in 0..1_000 {
+        let deadline = now + Duration::from_millis(1);
+        let mut delay = Box::pin(timer.delay_until(deadline));
+        assert!(poll(delay.as_mut()).is_pending());
+        drive(&mut driver, now);
+
+        let barrier = Arc::new(Barrier::new(2));
+        let drop_barrier = barrier.clone();
+        let dropping = std::thread::spawn(move || {
+            drop_barrier.wait();
+            drop(delay);
+        });
+        barrier.wait();
+        drive(&mut driver, deadline);
+        dropping.join().unwrap();
+        drive(&mut driver, deadline);
+        assert_eq!(driver.wheel.len(), 0);
+        now = deadline;
+    }
+}
+
+#[test]
+fn fixed_rate_task_longer_than_period_stays_on_the_grid() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    let starts = Arc::new(Mutex::new(Vec::new()));
+    let observed = starts.clone();
+    let clock = timer.clone();
+
+    // Each invocation occupies 35ms of the timeline, so it misses three 10ms grid points. The
+    // task has to consume that time itself: advancing the clock only between polls would let the
+    // scheduler observe the pre-task instant and would not model an overrun at all.
+    let mut schedule = Box::pin(schedule_at_fixed_rate(
+        &timer,
+        None,
+        Duration::from_millis(10),
+        async move || {
+            observed.lock().unwrap().push(clock.now() - genesis);
+            let _ = clock.delay(Duration::from_millis(35)).await;
+        },
+    ));
+
+    assert!(poll(schedule.as_mut()).is_pending());
+    for millis in [35, 40, 75, 80] {
+        drive(&mut driver, genesis + Duration::from_millis(millis));
+        assert!(poll(schedule.as_mut()).is_pending());
+    }
+
+    let starts = starts.lock().unwrap().clone();
+    assert_eq!(
+        starts,
+        vec![
+            Duration::ZERO,
+            Duration::from_millis(40),
+            Duration::from_millis(80),
+        ],
+        "an overrunning task must skip missed grid points, not run back to back"
+    );
+}
+
+// These Loom cases are protocol litmus tests, not instrumentation of the production types. Their
+// sequences mirror `DriverWake::{notify_after_send, mark_empty, arm}` and
+// `DelayWakeSlot::{register_and_load, take_after_publish}` and must stay aligned with them.
+#[test]
+fn model_driver_clear_and_producer_publish_cannot_both_miss() {
+    loom::model(|| {
+        use loom::sync::Arc;
+        use loom::sync::atomic::AtomicBool;
+        use loom::sync::atomic::Ordering;
+        use loom::sync::atomic::fence;
+        use loom::thread;
+
+        // `queued` stands in for the operation channel: the producer publishes an operation and
+        // only then sets `pending`. `pending` starts set, which is the interleaving where the
+        // producer takes the non-first path and never touches the wake slot.
+        let queued = Arc::new(AtomicBool::new(false));
+        let pending = Arc::new(AtomicBool::new(true));
+
+        let producer_queued = queued.clone();
+        let producer_pending = pending.clone();
+        let producer = thread::spawn(move || {
+            producer_queued.store(true, Ordering::Release);
+            // Isolate the leading clear/recheck fence; the trailing fence has its own model below.
+            fence(Ordering::SeqCst);
+            producer_pending.swap(true, Ordering::AcqRel);
+        });
+
+        let driver_queued = queued.clone();
+        let driver_pending = pending.clone();
+        let driver = thread::spawn(move || {
+            driver_pending.store(false, Ordering::Release);
+            fence(Ordering::SeqCst);
+            driver_queued.load(Ordering::Acquire)
+        });
+
+        let saw_queued = driver.join().unwrap();
+        producer.join().unwrap();
+        assert!(
+            saw_queued || pending.load(Ordering::SeqCst),
+            "the driver cleared `pending` and missed the queued operation"
+        );
+    });
+}
+
+#[test]
+fn concurrent_drain_and_send_never_park_with_queued_operations() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+
+    // Exercises the clear/recheck handshake against the real channel rather than a model of it.
+    for _ in 0..1_000 {
+        let barrier = Arc::new(Barrier::new(2));
+        let sender_barrier = barrier.clone();
+        let sender_timer = timer.clone();
+        let sender = std::thread::spawn(move || {
+            let mut delay = Box::pin(sender_timer.delay(Duration::from_secs(1)));
+            sender_barrier.wait();
+            assert!(poll(delay.as_mut()).is_pending());
+            delay
+        });
+
+        barrier.wait();
+        let result = driver.turn(genesis, budget());
+        let delay = sender.join().unwrap();
+
+        let counter = Arc::new(WakeCount::default());
+        let waker = Waker::from(counter.clone());
+        let parked = !result.has_more_work() && driver.register_wake(&waker);
+        assert!(
+            !parked || driver.turn(genesis, budget()).has_more_work() || driver.wheel.len() == 1,
+            "driver parked while a registration was still queued"
+        );
+
+        drive(&mut driver, genesis);
+        assert_eq!(driver.wheel.len(), 1);
+        drop(delay);
+        drive(&mut driver, genesis);
+        assert_eq!(driver.wheel.len(), 0);
+    }
+}
+
+#[test]
+fn repeated_polls_reuse_the_registered_waker() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    let counter = Arc::new(WakeCount::default());
+    let waker = Waker::from(counter.clone());
+    let mut delay = Box::pin(timer.delay(Duration::from_millis(1)));
+
+    assert!(poll_with_waker(delay.as_mut(), &waker).is_pending());
+    drive(&mut driver, genesis);
+    for _ in 0..16 {
+        assert!(poll_with_waker(delay.as_mut(), &waker).is_pending());
+    }
+
+    // A repoll with the same waker must not disarm the slot the driver is going to take.
+    drive(&mut driver, genesis + Duration::from_millis(1));
+    assert_eq!(counter.0.load(Ordering::Relaxed), 1);
+    assert_eq!(poll_with_waker(delay.as_mut(), &waker), Poll::Ready(Ok(())));
+}
+
+#[test]
+fn a_changed_waker_is_republished() {
+    let genesis = Instant::now();
+    let (mut driver, timer) = TimerDriver::new_at(genesis);
+    let first = Arc::new(WakeCount::default());
+    let second = Arc::new(WakeCount::default());
+    let first_waker = Waker::from(first.clone());
+    let second_waker = Waker::from(second.clone());
+    let mut delay = Box::pin(timer.delay(Duration::from_millis(1)));
+
+    assert!(poll_with_waker(delay.as_mut(), &first_waker).is_pending());
+    drive(&mut driver, genesis);
+    assert!(poll_with_waker(delay.as_mut(), &second_waker).is_pending());
+
+    drive(&mut driver, genesis + Duration::from_millis(1));
+    assert_eq!(first.0.load(Ordering::Relaxed), 0);
+    assert_eq!(second.0.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn model_driver_arm_and_publish_cannot_both_miss() {
+    loom::model(|| {
+        use loom::sync::Arc;
+        use loom::sync::atomic::AtomicBool;
+        use loom::sync::atomic::Ordering;
+        use loom::sync::atomic::fence;
+        use loom::thread;
+
+        let pending = Arc::new(AtomicBool::new(false));
+        let wake_slot = Arc::new(AtomicBool::new(false));
+
+        let driver_pending = pending.clone();
+        let driver_slot = wake_slot.clone();
+        let driver = thread::spawn(move || {
+            driver_slot.swap(true, Ordering::AcqRel);
+            fence(Ordering::SeqCst);
+            let saw_pending = driver_pending.load(Ordering::Acquire);
+            if saw_pending {
+                driver_slot.swap(false, Ordering::Acquire);
+            }
+            saw_pending
+        });
+
+        let producer_pending = pending.clone();
+        let producer_slot = wake_slot.clone();
+        let producer = thread::spawn(move || {
+            // The leading clear/recheck fence is isolated in the preceding model.
+            let first = !producer_pending.swap(true, Ordering::AcqRel);
+            fence(Ordering::SeqCst);
+            if first {
+                producer_slot.swap(false, Ordering::Acquire)
+            } else {
+                false
+            }
+        });
+
+        let saw_pending = driver.join().unwrap();
+        let took_waker = producer.join().unwrap();
+        assert!(saw_pending || took_waker);
+    });
+}
+
+#[test]
+fn model_delay_registration_and_terminal_publish_cannot_both_miss() {
+    loom::model(|| {
+        use loom::sync::Arc;
+        use loom::sync::atomic::AtomicBool;
+        use loom::sync::atomic::AtomicUsize;
+        use loom::sync::atomic::Ordering;
+        use loom::sync::atomic::fence;
+        use loom::thread;
+
+        let lifecycle = Arc::new(AtomicUsize::new(STATE_REGISTERED as usize));
+        let wake_slot = Arc::new(AtomicBool::new(false));
+
+        let poll_lifecycle = lifecycle.clone();
+        let poll_slot = wake_slot.clone();
+        let polling = thread::spawn(move || {
+            poll_slot.swap(true, Ordering::AcqRel);
+            fence(Ordering::SeqCst);
+            poll_lifecycle.load(Ordering::Acquire) == STATE_FIRED as usize
+        });
+
+        let publish_lifecycle = lifecycle.clone();
+        let publish_slot = wake_slot.clone();
+        let publishing = thread::spawn(move || {
+            publish_lifecycle
+                .compare_exchange(
+                    STATE_REGISTERED as usize,
+                    STATE_FIRED as usize,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .unwrap();
+            fence(Ordering::SeqCst);
+            publish_slot.swap(false, Ordering::Acquire)
+        });
+
+        let saw_terminal = polling.join().unwrap();
+        let took_waker = publishing.join().unwrap();
+        assert!(saw_terminal || took_waker);
+    });
+}

--- a/mea/src/time/wheel.rs
+++ b/mea/src/time/wheel.rs
@@ -1,0 +1,622 @@
+// Copyright 2024 tison <wander4096@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Private hierarchical timing wheel used by the explicit timer driver.
+//!
+//! Finite deadlines are stored in six levels of intrusive slot lists. Deadlines outside the moving
+//! wheel horizon stay in an ordered overflow map until they can be promoted; elapsed and
+//! unrepresentable deadlines use separate lists.
+
+use std::array;
+use std::collections::BTreeMap;
+use std::time::Duration;
+use std::time::Instant;
+
+use slab::Slab;
+
+const LEVELS: usize = 6;
+const SLOTS: usize = u64::BITS as usize;
+const TICK_MILLIS: u64 = 1;
+const TICK: Duration = Duration::from_millis(TICK_MILLIS);
+pub(super) const HORIZON: u64 = (SLOTS as u64).pow(LEVELS as u32);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum Deadline {
+    At(Instant),
+    Never,
+}
+
+impl Deadline {
+    pub(super) fn checked_add(base: Instant, duration: Duration) -> Self {
+        base.checked_add(duration).map_or(Self::Never, Self::At)
+    }
+
+    pub(super) fn as_instant(self) -> Option<Instant> {
+        match self {
+            Self::At(instant) => Some(instant),
+            Self::Never => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct List {
+    head: Option<usize>,
+    tail: Option<usize>,
+}
+
+/// The collection currently owning a wheel entry.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Location {
+    Immediate,
+    Wheel { level: usize, slot: usize },
+    Overflow(Instant),
+    Never,
+}
+
+struct Node<T> {
+    deadline: Deadline,
+    location: Option<Location>,
+    next: Option<usize>,
+    prev: Option<usize>,
+    value: T,
+}
+
+/// One unit of work charged against the driver's timer-entry budget.
+pub(super) enum Step {
+    /// One entry was moved between wheel tiers without becoming ready.
+    Examined,
+    /// The identified entry is ready for the driver to remove and fire.
+    Fire(usize),
+}
+
+/// Slab-backed timer entries partitioned by deadline range.
+pub(super) struct Wheel<T> {
+    entries: Slab<Node<T>>,
+    genesis: Instant,
+    immediate: List,
+    never: List,
+    // Bit `slot` is set when that level's intrusive slot list is non-empty.
+    occupancy: [u64; LEVELS],
+    overflow: BTreeMap<Instant, List>,
+    position: u64,
+    slots: [[List; SLOTS]; LEVELS],
+}
+
+impl<T> Wheel<T> {
+    pub(super) fn new(genesis: Instant) -> Self {
+        Self {
+            entries: Slab::new(),
+            genesis,
+            immediate: List::default(),
+            never: List::default(),
+            occupancy: [0; LEVELS],
+            overflow: BTreeMap::new(),
+            position: 0,
+            slots: array::from_fn(|_| array::from_fn(|_| List::default())),
+        }
+    }
+
+    pub(super) fn insert(&mut self, deadline: Deadline, now: Instant, value: T) -> usize {
+        let location = self.classify(deadline, now);
+        let id = self.entries.insert(Node {
+            deadline,
+            location: None,
+            next: None,
+            prev: None,
+            value,
+        });
+        self.link_back(id, location);
+        id
+    }
+
+    pub(super) fn get(&self, id: usize) -> Option<&T> {
+        self.entries.get(id).map(|node| &node.value)
+    }
+
+    pub(super) fn remove(&mut self, id: usize) -> Option<T> {
+        if !self.entries.contains(id) {
+            return None;
+        }
+        self.unlink(id);
+        Some(self.entries.remove(id).value)
+    }
+
+    pub(super) fn step_immediate(&self) -> Option<Step> {
+        self.immediate.head.map(Step::Fire)
+    }
+
+    #[cfg(test)]
+    fn step(&mut self, now: Instant) -> Option<Step> {
+        self.step_immediate()
+            .or_else(|| self.step_non_immediate(now))
+    }
+
+    pub(super) fn step_non_immediate(&mut self, now: Instant) -> Option<Step> {
+        let now_tick = self.floor_tick(now);
+        if let Some((boundary, level, slot)) = self.next_wheel_boundary() {
+            if boundary <= now_tick {
+                self.position = boundary;
+                let location = Location::Wheel { level, slot };
+                let id = self
+                    .list(location)
+                    .head
+                    .expect("occupied slot must be non-empty");
+                if level == 0 || self.deadline_elapsed(id, now) {
+                    return Some(Step::Fire(id));
+                }
+
+                self.unlink(id);
+                let location = self.classify(self.entries[id].deadline, now);
+                self.link_back(id, location);
+                return Some(Step::Examined);
+            }
+        }
+
+        if let Some((&deadline, list)) = self.overflow.first_key_value() {
+            if self.overflow_ready(deadline, now) {
+                let id = list.head.expect("overflow bucket must be non-empty");
+                if deadline <= now {
+                    return Some(Step::Fire(id));
+                }
+
+                self.position = now_tick;
+                self.unlink(id);
+                let location = self.classify(self.entries[id].deadline, now);
+                self.link_back(id, location);
+                return Some(Step::Examined);
+            }
+        }
+
+        self.position = now_tick;
+        None
+    }
+
+    pub(super) fn has_due(&self, now: Instant) -> bool {
+        if !self.immediate_is_empty() {
+            return true;
+        }
+        let now_tick = self.floor_tick(now);
+        if self
+            .next_wheel_boundary()
+            .is_some_and(|(boundary, _, _)| boundary <= now_tick)
+        {
+            return true;
+        }
+        self.overflow
+            .first_key_value()
+            .is_some_and(|(&deadline, _)| self.overflow_ready(deadline, now))
+    }
+
+    pub(super) fn settle(&mut self, now: Instant) {
+        debug_assert!(!self.has_due(now));
+        self.position = self.floor_tick(now);
+    }
+
+    pub(super) fn next_poll_at(&self, now: Instant) -> Option<Instant> {
+        if self.has_due(now) {
+            return Some(now);
+        }
+
+        let wheel = self
+            .next_wheel_boundary()
+            .and_then(|(tick, _, _)| self.instant_for_tick(tick));
+        let overflow = self
+            .overflow
+            .first_key_value()
+            .map(|(&deadline, _)| self.promotion_instant(deadline));
+        match (wheel, overflow) {
+            (Some(wheel), Some(overflow)) => Some(wheel.min(overflow)),
+            (Some(wheel), None) => Some(wheel),
+            (None, Some(overflow)) => Some(overflow),
+            (None, None) => None,
+        }
+    }
+
+    pub(super) fn drain(&mut self) -> impl Iterator<Item = T> + '_ {
+        self.immediate = List::default();
+        self.never = List::default();
+        self.occupancy = [0; LEVELS];
+        self.overflow.clear();
+        self.slots = array::from_fn(|_| array::from_fn(|_| List::default()));
+        self.entries.drain().map(|node| node.value)
+    }
+
+    #[cfg(test)]
+    pub(super) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn classify(&self, deadline: Deadline, now: Instant) -> Location {
+        let Deadline::At(deadline) = deadline else {
+            return Location::Never;
+        };
+        if deadline <= now {
+            return Location::Immediate;
+        }
+
+        let Some(tick) = self.ceil_tick(deadline) else {
+            return Location::Overflow(deadline);
+        };
+        let Some(delta) = tick.checked_sub(self.position) else {
+            return Location::Immediate;
+        };
+        if delta >= HORIZON {
+            return Location::Overflow(deadline);
+        }
+
+        let level = level_for_delta(delta);
+        let width = level_width(level);
+        let slot = ((tick / width) % SLOTS as u64) as usize;
+        Location::Wheel { level, slot }
+    }
+
+    fn deadline_elapsed(&self, id: usize, now: Instant) -> bool {
+        match self.entries[id].deadline {
+            Deadline::At(deadline) => deadline <= now,
+            Deadline::Never => false,
+        }
+    }
+
+    fn floor_tick(&self, instant: Instant) -> u64 {
+        if instant <= self.genesis {
+            return 0;
+        }
+        let elapsed_millis = instant.duration_since(self.genesis).as_millis();
+        let ticks = elapsed_millis / u128::from(TICK_MILLIS);
+        u64::try_from(ticks).unwrap_or(u64::MAX)
+    }
+
+    fn ceil_tick(&self, instant: Instant) -> Option<u64> {
+        if instant <= self.genesis {
+            return Some(0);
+        }
+        let nanos = instant.duration_since(self.genesis).as_nanos();
+        let tick_nanos = TICK.as_nanos();
+        let ticks = nanos.checked_add(tick_nanos - 1)? / tick_nanos;
+        u64::try_from(ticks).ok()
+    }
+
+    fn instant_for_tick(&self, tick: u64) -> Option<Instant> {
+        tick.checked_mul(TICK_MILLIS)
+            .and_then(|millis| self.genesis.checked_add(Duration::from_millis(millis)))
+    }
+
+    fn promotion_instant(&self, deadline: Instant) -> Instant {
+        let Some(tick) = self.ceil_tick(deadline) else {
+            // This deadline is outside the wheel's u64 tick domain. Keep it in overflow until the
+            // deadline itself rather than repeatedly attempting an impossible promotion.
+            return deadline;
+        };
+        tick.checked_sub(HORIZON - 1)
+            .and_then(|tick| self.instant_for_tick(tick))
+            .unwrap_or(self.genesis)
+    }
+
+    fn overflow_ready(&self, deadline: Instant, now: Instant) -> bool {
+        self.promotion_instant(deadline) <= now
+    }
+
+    fn immediate_is_empty(&self) -> bool {
+        self.immediate.head.is_none()
+    }
+
+    fn next_wheel_boundary(&self) -> Option<(u64, usize, usize)> {
+        let mut result = None;
+        for (level, &occupancy) in self.occupancy.iter().enumerate() {
+            let mut bits = occupancy;
+            while bits != 0 {
+                let slot = bits.trailing_zeros() as usize;
+                bits &= bits - 1;
+                let Some(boundary) = occurrence_start(self.position, level, slot) else {
+                    debug_assert!(
+                        false,
+                        "occupied slot {slot} at level {level} overflowed the tick domain"
+                    );
+                    continue;
+                };
+                if result.is_none_or(|(current, _, _)| boundary < current) {
+                    result = Some((boundary, level, slot));
+                }
+            }
+        }
+        result
+    }
+
+    fn list(&self, location: Location) -> List {
+        match location {
+            Location::Immediate => self.immediate,
+            Location::Wheel { level, slot } => self.slots[level][slot],
+            Location::Overflow(deadline) => self.overflow[&deadline],
+            Location::Never => self.never,
+        }
+    }
+
+    fn set_list(&mut self, location: Location, list: List) {
+        match location {
+            Location::Immediate => self.immediate = list,
+            Location::Wheel { level, slot } => {
+                self.slots[level][slot] = list;
+                if list.head.is_some() {
+                    self.occupancy[level] |= 1 << slot;
+                } else {
+                    self.occupancy[level] &= !(1 << slot);
+                }
+            }
+            Location::Overflow(deadline) => {
+                if list.head.is_some() {
+                    self.overflow.insert(deadline, list);
+                } else {
+                    self.overflow.remove(&deadline);
+                }
+            }
+            Location::Never => self.never = list,
+        }
+    }
+
+    fn link_back(&mut self, id: usize, location: Location) {
+        debug_assert!(self.entries[id].location.is_none());
+        let mut list = match location {
+            Location::Overflow(deadline) => {
+                self.overflow.get(&deadline).copied().unwrap_or_default()
+            }
+            _ => self.list(location),
+        };
+        if let Some(tail) = list.tail {
+            self.entries[tail].next = Some(id);
+        } else {
+            list.head = Some(id);
+        }
+        self.entries[id].location = Some(location);
+        self.entries[id].prev = list.tail;
+        self.entries[id].next = None;
+        list.tail = Some(id);
+        self.set_list(location, list);
+    }
+
+    fn unlink(&mut self, id: usize) {
+        let node = &self.entries[id];
+        let location = node.location.expect("linked node must have a location");
+        let prev = node.prev;
+        let next = node.next;
+        let mut list = self.list(location);
+
+        if let Some(prev) = prev {
+            self.entries[prev].next = next;
+        } else {
+            list.head = next;
+        }
+        if let Some(next) = next {
+            self.entries[next].prev = prev;
+        } else {
+            list.tail = prev;
+        }
+
+        let node = &mut self.entries[id];
+        node.location = None;
+        node.prev = None;
+        node.next = None;
+        self.set_list(location, list);
+    }
+}
+
+fn level_width(level: usize) -> u64 {
+    (SLOTS as u64).pow(level as u32)
+}
+
+fn level_for_delta(delta: u64) -> usize {
+    for level in 0..LEVELS - 1 {
+        if delta < level_width(level + 1) {
+            return level;
+        }
+    }
+    LEVELS - 1
+}
+
+fn occurrence_start(position: u64, level: usize, slot: usize) -> Option<u64> {
+    let width = level_width(level);
+    let cycle = width.checked_mul(SLOTS as u64)?;
+    let base = position / cycle * cycle;
+    let mut candidate = base.checked_add((slot as u64).checked_mul(width)?)?;
+    if candidate < position {
+        candidate = candidate.checked_add(cycle)?;
+    }
+    Some(candidate)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    fn at(genesis: Instant, millis: u64) -> Instant {
+        genesis
+            .checked_add(Duration::from_millis(millis))
+            .expect("test instant must be representable")
+    }
+
+    fn reset_randomized_wheel(
+        wheel: &mut Wheel<u64>,
+        oracle: &mut BTreeMap<u64, u64>,
+        live: &mut Vec<(usize, u64)>,
+        genesis: Instant,
+    ) {
+        for (wheel_id, oracle_id) in live.drain(..) {
+            assert_eq!(wheel.remove(wheel_id), Some(oracle_id));
+            assert!(oracle.remove(&oracle_id).is_some());
+        }
+        assert!(oracle.is_empty());
+        *wheel = Wheel::new(genesis);
+    }
+
+    #[test]
+    fn levels_cover_exact_horizon() {
+        assert_eq!(level_for_delta(63), 0);
+        assert_eq!(level_for_delta(64), 1);
+        assert_eq!(level_for_delta(4095), 1);
+        assert_eq!(level_for_delta(4096), 2);
+        assert_eq!(level_for_delta(HORIZON - 1), 5);
+    }
+
+    #[test]
+    fn cascades_at_range_start_and_never_fires_early() {
+        let genesis = Instant::now();
+        let mut wheel = Wheel::new(genesis);
+        let id = wheel.insert(Deadline::At(at(genesis, 65)), genesis, 7);
+
+        assert!(wheel.step(at(genesis, 63)).is_none());
+        assert!(matches!(wheel.step(at(genesis, 64)), Some(Step::Examined)));
+        assert!(wheel.get(id).is_some());
+        assert!(wheel.step(at(genesis, 64)).is_none());
+        assert!(matches!(wheel.step(at(genesis, 65)), Some(Step::Fire(found)) if found == id));
+        assert_eq!(wheel.remove(id), Some(7));
+    }
+
+    #[test]
+    fn promotes_at_exact_horizon_boundary() {
+        let genesis = Instant::now();
+        let mut wheel = Wheel::new(genesis);
+        let deadline = at(genesis, HORIZON);
+        let id = wheel.insert(Deadline::At(deadline), genesis, 9);
+
+        assert_eq!(wheel.next_poll_at(genesis), Some(at(genesis, 1)));
+        assert!(matches!(wheel.step(at(genesis, 1)), Some(Step::Examined)));
+        assert!(wheel.get(id).is_some());
+        assert!(wheel.step(at(genesis, HORIZON - 1)).is_none());
+        assert!(matches!(wheel.step(deadline), Some(Step::Fire(found)) if found == id));
+    }
+
+    #[test]
+    fn submillisecond_overflow_waits_for_representable_position() {
+        let genesis = Instant::now();
+        let mut wheel = Wheel::new(genesis);
+        let deadline = genesis + Duration::from_micros(HORIZON * 1_000 + 500);
+        let id = wheel.insert(Deadline::At(deadline), genesis, 11);
+
+        assert_eq!(wheel.next_poll_at(genesis), Some(at(genesis, 2)));
+        assert!(wheel.step(genesis + Duration::from_micros(1_500)).is_none());
+        assert!(matches!(wheel.step(at(genesis, 2)), Some(Step::Examined)));
+        assert!(wheel.get(id).is_some());
+    }
+
+    #[test]
+    fn cancellation_unlinks_every_location() {
+        let genesis = Instant::now();
+        let mut wheel = Wheel::new(genesis);
+        let immediate = wheel.insert(Deadline::At(genesis), genesis, 1);
+        let near = wheel.insert(Deadline::At(at(genesis, 1)), genesis, 2);
+        let overflow = wheel.insert(Deadline::At(at(genesis, HORIZON)), genesis, 3);
+        let never = wheel.insert(Deadline::Never, genesis, 4);
+
+        assert_eq!(wheel.remove(immediate), Some(1));
+        assert_eq!(wheel.remove(near), Some(2));
+        assert_eq!(wheel.remove(overflow), Some(3));
+        assert_eq!(wheel.remove(never), Some(4));
+        assert_eq!(wheel.len(), 0);
+        assert_eq!(wheel.next_poll_at(genesis), None);
+    }
+
+    #[test]
+    fn randomized_operations_match_ordered_oracle() {
+        const MAX_TEST_MILLIS: u64 = HORIZON * 8;
+
+        let genesis = Instant::now();
+        let mut wheel = Wheel::new(genesis);
+        let mut oracle = BTreeMap::<u64, u64>::new();
+        let mut live = Vec::new();
+        let mut now = 0_u64;
+        let mut next_id = 0_u64;
+        let mut random = 0x4d59_5df4_d0f3_3173_u64;
+
+        for _ in 0..5_000 {
+            random = random
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1);
+            match random % 5 {
+                0 if !live.is_empty() => {
+                    let index = (random as usize / 5) % live.len();
+                    let (wheel_id, oracle_id) = live.swap_remove(index);
+                    assert_eq!(wheel.remove(wheel_id), Some(oracle_id));
+                    oracle.remove(&oracle_id);
+                }
+                1 | 2 => {
+                    let jump = match random % 8 {
+                        0 => 1,
+                        1 => 63,
+                        2 => 64,
+                        3 => 65,
+                        4 => 4096,
+                        5 => HORIZON - 1,
+                        6 => HORIZON,
+                        _ => random % 10_000,
+                    };
+                    let candidate = now.checked_add(jump).unwrap();
+                    if candidate > MAX_TEST_MILLIS {
+                        reset_randomized_wheel(&mut wheel, &mut oracle, &mut live, genesis);
+                        now = jump;
+                    } else {
+                        now = candidate;
+                    }
+                    while let Some(step) = wheel.step(at(genesis, now)) {
+                        if let Step::Fire(id) = step {
+                            let value = wheel.remove(id).unwrap();
+                            let deadline = oracle.remove(&value).unwrap();
+                            assert!(deadline <= now, "timer {value} fired early");
+                            if let Some(index) =
+                                live.iter().position(|&(wheel_id, _)| wheel_id == id)
+                            {
+                                live.swap_remove(index);
+                            }
+                        }
+                    }
+                    let expected: Vec<_> = oracle
+                        .iter()
+                        .filter_map(|(&id, &deadline)| (deadline <= now).then_some(id))
+                        .collect();
+                    assert!(
+                        expected.is_empty(),
+                        "due timers were not fired: {expected:?}"
+                    );
+                }
+                _ => {
+                    let distance = match random % 7 {
+                        0 => 0,
+                        1 => 1,
+                        2 => 63,
+                        3 => 64,
+                        4 => 4096,
+                        5 => HORIZON - 1,
+                        _ => HORIZON,
+                    };
+                    let mut deadline = now.checked_add(distance).unwrap();
+                    if deadline > MAX_TEST_MILLIS {
+                        reset_randomized_wheel(&mut wheel, &mut oracle, &mut live, genesis);
+                        now = 0;
+                        deadline = distance;
+                    }
+                    let id = wheel.insert(
+                        Deadline::At(at(genesis, deadline)),
+                        at(genesis, now),
+                        next_id,
+                    );
+                    oracle.insert(next_id, deadline);
+                    live.push((id, next_id));
+                    next_id += 1;
+                }
+            }
+        }
+        reset_randomized_wheel(&mut wheel, &mut oracle, &mut live, genesis);
+    }
+}


### PR DESCRIPTION
This is an initial implementation for fast/scorpio#1, developed with Codex.

As @tisonkun proposed, timer-related primitives are a natural next step now that most common primitives in `mea` are in place. The timer side starts with a reactor-oriented design instead of a standalone runtime-agnostic abstraction, since a timing wheel and driver effectively form a timer reactor. In this direction, `delay_until` is the runtime-dependent primitive, while delays, timeouts, intervals, and scheduled actions can be composed on top of it. Timer capability is passed explicitly through `TimerContext` instead of relying on a Tokio-style current handle.

## Summary

- add an explicitly driven `TimerDriver` and cloneable `TimerContext`, with bounded turns and replaceable reactor wake registration
- add lazy, cancellation-safe `Delay` futures and report driver closure separately from deadline expiration
- add `timeout` and `timeout_at`, intervals with `Burst`, `Delay`, and `Skip` behavior, and three non-spawning scheduling helpers
- keep the six-level, 1 ms hierarchical timing wheel, ordered overflow tier, operation queue, and lifecycle protocol private
- add deterministic driven-clock tests, concurrent race tests, and small Loom models for the wake protocols

## Verification

- `cargo +1.85.0 test --workspace --no-default-features`
- `cargo +stable test --workspace --no-default-features`
- `cargo x lint`

@tisonkun, could you take an initial look at the timer/reactor boundary? Since `mea` does not have a reactor yet, this PR exposes `TimerDriver`, `TurnBudget`, and `TurnResult`, and keeps `TimerContext` standalone so the timer can be driven explicitly for now. I would especially like your opinion on whether this is a reasonable first shape before reactor integration.

Closes fast/scorpio#1.
