### PR TITLE
fix: clean up abandoned keyed once cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to this project will be documented in this file.
 * Align `Condvar` with standard condition-variable semantics by notifying only current waiters and passing a cancelled `notify_one` wakeup to another current waiter instead of storing a permit.
 * Clean up uninitialized `OnceMap` and `singleflight` entries once no callers remain after a failure, panic, or cancellation.
 
+### Improvements
+
+* Remove unnecessary `Clone` bounds from `singleflight` keys and custom hashers used by keyed once primitives.
+
 ## v0.6.5 (2026-07-30)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 * Retry spurious atomic failures when completing `Once` initialization. ([#126](https://github.com/fast/mea/pull/126))
 * Make cloning a `WaitGroup` panic on counter overflow instead of silently losing track of a handle.
 * Align `Condvar` with standard condition-variable semantics by notifying only current waiters and passing a cancelled `notify_one` wakeup to another current waiter instead of storing a permit.
+* Clean up uninitialized `OnceMap` and `singleflight` entries once no callers remain after a failure, panic, or cancellation.
 
 ## v0.6.5 (2026-07-30)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,7 @@ name = "mea"
 version = "0.6.5"
 dependencies = [
  "divan",
+ "hashbrown",
  "pollster",
  "slab",
  "tokio",

--- a/mea/Cargo.toml
+++ b/mea/Cargo.toml
@@ -33,6 +33,9 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+hashbrown = { version = "0.17.1", default-features = false, features = [
+  "inline-more",
+] }
 slab = { version = "0.4.11" }
 
 [dev-dependencies]

--- a/mea/benches/primitives/main.rs
+++ b/mea/benches/primitives/main.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod once_map;
 mod oneshot;
+mod singleflight;
+mod support;
 
 fn main() {
     divan::main();

--- a/mea/benches/primitives/once_map.rs
+++ b/mea/benches/primitives/once_map.rs
@@ -1,0 +1,69 @@
+// Copyright 2024 tison <wander4096@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use divan::Bencher;
+use divan::black_box;
+use mea::once::OnceMap;
+
+use super::support::defer_input_drop;
+use super::support::noop_context;
+use super::support::poll_ready;
+
+const CACHED_ENTRY_COUNTS: &[usize] = &[0, 64, 1024];
+
+#[divan::bench]
+fn compute_vacant(bencher: Bencher) {
+    let mut context = noop_context();
+    bencher
+        .with_inputs(OnceMap::<usize, usize>::new)
+        .bench_local_values(|map| {
+            let result = black_box(poll_ready(
+                map.compute(black_box(0), || async { black_box(1) }),
+                &mut context,
+            ));
+            defer_input_drop(map, result)
+        });
+}
+
+#[divan::bench]
+fn compute_occupied(bencher: Bencher) {
+    let mut context = noop_context();
+    bencher
+        .with_inputs(|| [(0, 1)].into_iter().collect::<OnceMap<_, _>>())
+        .bench_local_values(|map| {
+            let result = black_box(poll_ready(
+                map.compute(black_box(0), || async { black_box(2) }),
+                &mut context,
+            ));
+            defer_input_drop(map, result)
+        });
+}
+
+#[divan::bench(args = CACHED_ENTRY_COUNTS)]
+fn try_compute_error(bencher: Bencher, cached_entries: usize) {
+    let mut context = noop_context();
+    bencher
+        .with_inputs(|| {
+            (0..cached_entries)
+                .map(|key| (key, key))
+                .collect::<OnceMap<_, _>>()
+        })
+        .bench_local_values(|map| {
+            let result = black_box(poll_ready(
+                map.try_compute(black_box(usize::MAX), || async { Err::<usize, ()>(()) }),
+                &mut context,
+            ));
+            defer_input_drop(map, result)
+        });
+}

--- a/mea/benches/primitives/singleflight.rs
+++ b/mea/benches/primitives/singleflight.rs
@@ -1,0 +1,49 @@
+// Copyright 2024 tison <wander4096@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use divan::Bencher;
+use divan::black_box;
+use mea::singleflight::Group;
+
+use super::support::defer_input_drop;
+use super::support::noop_context;
+use super::support::poll_ready;
+
+#[divan::bench]
+fn work_ready(bencher: Bencher) {
+    let mut context = noop_context();
+    bencher
+        .with_inputs(Group::<usize, usize>::new)
+        .bench_local_values(|group| {
+            let result = black_box(poll_ready(
+                group.work(black_box(0), || async { black_box(1) }),
+                &mut context,
+            ));
+            defer_input_drop(group, result)
+        });
+}
+
+#[divan::bench]
+fn try_work_error(bencher: Bencher) {
+    let mut context = noop_context();
+    bencher
+        .with_inputs(Group::<usize, usize>::new)
+        .bench_local_values(|group| {
+            let result = black_box(poll_ready(
+                group.try_work(black_box(0), || async { Err::<usize, ()>(()) }),
+                &mut context,
+            ));
+            defer_input_drop(group, result)
+        });
+}

--- a/mea/benches/primitives/support.rs
+++ b/mea/benches/primitives/support.rs
@@ -1,0 +1,37 @@
+// Copyright 2024 tison <wander4096@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+use std::pin::pin;
+use std::task::Context;
+use std::task::Poll;
+use std::task::Waker;
+
+pub(super) fn noop_context() -> Context<'static> {
+    Context::from_waker(Waker::noop())
+}
+
+pub(super) fn poll_ready<F: Future>(future: F, context: &mut Context<'_>) -> F::Output {
+    let mut future = pin!(future);
+    match future.as_mut().poll(context) {
+        Poll::Ready(output) => output,
+        Poll::Pending => panic!("benchmark future should be ready"),
+    }
+}
+
+// Move the input into the benchmark output so Divan drops it outside the timed section.
+#[inline]
+pub(super) fn defer_input_drop<I, O>(input: I, output: O) -> (I, O) {
+    (input, output)
+}

--- a/mea/src/admission/tests.rs
+++ b/mea/src/admission/tests.rs
@@ -13,25 +13,15 @@
 // limitations under the License.
 
 use std::collections::hash_map::DefaultHasher;
-use std::future::Future;
 use std::hash::BuildHasherDefault;
-use std::pin::Pin;
 use std::pin::pin;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
-use std::task::Context;
 use std::task::Poll;
-use std::task::Waker;
 
 use super::FairShare;
-
-fn poll_once<F>(future: Pin<&mut F>) -> Poll<F::Output>
-where
-    F: Future,
-{
-    future.poll(&mut Context::from_waker(Waker::noop()))
-}
+use crate::poll_once;
 
 #[test]
 #[should_panic(expected = "FairShare requires at least one permit")]

--- a/mea/src/condvar/tests.rs
+++ b/mea/src/condvar/tests.rs
@@ -12,25 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::Context;
 use std::task::Poll;
-use std::task::Waker;
 
 use tokio::task::JoinHandle;
 
 use crate::condvar::Condvar;
 use crate::mutex::Mutex;
+use crate::poll_once;
 use crate::test_runtime;
-
-fn poll_once<F>(future: Pin<&mut F>) -> Poll<F::Output>
-where
-    F: Future,
-{
-    future.poll(&mut Context::from_waker(Waker::noop()))
-}
 
 fn expect_ready<T>(poll: Poll<T>) -> T {
     match poll {

--- a/mea/src/internal/keyed_once.rs
+++ b/mea/src/internal/keyed_once.rs
@@ -1,0 +1,161 @@
+// Copyright 2024 tison <wander4096@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared storage for keyed once primitives.
+//!
+//! Keeping the key and cell in one `Arc` lets calls retain an entry's identity without requiring
+//! `K: Clone`. `HashTable` provides hashed lookup with a custom equality check, preserving borrowed
+//! key lookups and expected O(1) removal of an exact entry.
+
+use std::borrow::Borrow;
+use std::fmt;
+use std::hash::BuildHasher;
+use std::hash::Hash;
+use std::sync::Arc;
+
+use hashbrown::HashTable;
+
+use crate::once::OnceCell;
+
+pub(crate) struct KeyedOnceEntry<K, V> {
+    hash: u64,
+    key: K,
+    cell: OnceCell<V>,
+}
+
+impl<K, V> KeyedOnceEntry<K, V> {
+    pub(crate) fn cell(&self) -> &OnceCell<V> {
+        &self.cell
+    }
+}
+
+pub(crate) struct KeyedOnceTable<K, V, S> {
+    entries: HashTable<Arc<KeyedOnceEntry<K, V>>>,
+    hash_builder: S,
+}
+
+impl<K, V, S> fmt::Debug for KeyedOnceTable<K, V, S>
+where
+    K: fmt::Debug,
+    V: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_map()
+            .entries(self.entries.iter().map(|entry| (&entry.key, &entry.cell)))
+            .finish()
+    }
+}
+
+impl<K, V, S> KeyedOnceTable<K, V, S> {
+    pub(crate) fn with_hasher(hash_builder: S) -> Self {
+        Self {
+            entries: HashTable::new(),
+            hash_builder,
+        }
+    }
+
+    pub(crate) fn with_capacity_and_hasher(capacity: usize, hash_builder: S) -> Self {
+        Self {
+            entries: HashTable::with_capacity(capacity),
+            hash_builder,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+impl<K, V, S> KeyedOnceTable<K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    pub(crate) fn get_or_insert(&mut self, key: K) -> &Arc<KeyedOnceEntry<K, V>> {
+        let hash = self.hash_builder.hash_one(&key);
+        self.entries
+            .entry(hash, |entry| entry.key.eq(&key), |entry| entry.hash)
+            .or_insert_with(|| {
+                Arc::new(KeyedOnceEntry {
+                    hash,
+                    key,
+                    cell: OnceCell::new(),
+                })
+            })
+            .into_mut()
+    }
+
+    pub(crate) fn get<Q>(&self, key: &Q) -> Option<&Arc<KeyedOnceEntry<K, V>>>
+    where
+        K: Borrow<Q>,
+        Q: Eq + Hash + ?Sized,
+    {
+        let hash = self.hash_builder.hash_one(key);
+        self.entries.find(hash, |entry| entry.key.borrow() == key)
+    }
+
+    pub(crate) fn remove<Q>(&mut self, key: &Q) -> Option<Arc<KeyedOnceEntry<K, V>>>
+    where
+        K: Borrow<Q>,
+        Q: Eq + Hash + ?Sized,
+    {
+        let hash = self.hash_builder.hash_one(key);
+        let entry = self
+            .entries
+            .find_entry(hash, |entry| entry.key.borrow() == key)
+            .ok()?;
+        let (entry, _) = entry.remove();
+        Some(entry)
+    }
+
+    /// Removes the entry only if the table still contains the same allocation.
+    pub(crate) fn remove_exact(&mut self, expected: &Arc<KeyedOnceEntry<K, V>>) -> bool {
+        let Ok(entry) = self
+            .entries
+            .find_entry(expected.hash, |entry| Arc::ptr_eq(entry, expected))
+        else {
+            return false;
+        };
+
+        drop(entry.remove());
+        true
+    }
+
+    pub(crate) fn remove_abandoned(&mut self, entry: &Arc<KeyedOnceEntry<K, V>>) {
+        // If the table still owns this entry, a count of two means the current call is its only
+        // owner outside the table. remove_exact also rejects an entry that was detached or
+        // replaced.
+        if Arc::strong_count(entry) == 2 && entry.cell.get().is_none() {
+            self.remove_exact(entry);
+        }
+    }
+
+    pub(crate) fn insert_value(&mut self, key: K, value: V) {
+        self.remove(&key);
+
+        let hash = self.hash_builder.hash_one(&key);
+        let entry = Arc::new(KeyedOnceEntry {
+            hash,
+            key,
+            cell: OnceCell::from_value(value),
+        });
+        self.entries.insert_unique(hash, entry, |entry| entry.hash);
+    }
+}

--- a/mea/src/internal/mod.rs
+++ b/mea/src/internal/mod.rs
@@ -15,8 +15,8 @@
 mod countdown;
 pub(crate) use countdown::*;
 
-mod keyed_once;
-pub(crate) use keyed_once::*;
+mod once_table;
+pub(crate) use once_table::*;
 
 mod mutex;
 pub(crate) use mutex::*;

--- a/mea/src/internal/mod.rs
+++ b/mea/src/internal/mod.rs
@@ -15,6 +15,9 @@
 mod countdown;
 pub(crate) use countdown::*;
 
+mod keyed_once;
+pub(crate) use keyed_once::*;
+
 mod mutex;
 pub(crate) use mutex::*;
 

--- a/mea/src/internal/once_table.rs
+++ b/mea/src/internal/once_table.rs
@@ -19,7 +19,6 @@ use std::hash::Hash;
 use std::sync::Arc;
 
 use hashbrown::HashTable;
-use hashbrown::hash_table::OccupiedEntry;
 
 use crate::once::OnceCell;
 
@@ -30,8 +29,26 @@ pub struct OnceTableEntry<K, V> {
 }
 
 impl<K, V> OnceTableEntry<K, V> {
-    pub fn cell(&self) -> &OnceCell<V> {
-        &self.cell
+    pub fn initialized(&self) -> bool {
+        self.cell.initialized()
+    }
+
+    pub fn get(&self) -> Option<&V> {
+        self.cell.get()
+    }
+
+    pub async fn get_or_init<F>(&self, init: F) -> &V
+    where
+        F: AsyncFnOnce() -> V,
+    {
+        self.cell.get_or_init(init).await
+    }
+
+    pub async fn get_or_try_init<E, F>(&self, init: F) -> Result<&V, E>
+    where
+        F: AsyncFnOnce() -> Result<V, E>,
+    {
+        self.cell.get_or_try_init(init).await
     }
 }
 
@@ -84,7 +101,7 @@ where
     K: Eq + Hash,
     S: BuildHasher,
 {
-    pub fn get_or_insert(&mut self, key: K) -> OccupiedEntry<'_, Arc<OnceTableEntry<K, V>>> {
+    pub fn get_or_insert(&mut self, key: K) -> &Arc<OnceTableEntry<K, V>> {
         let hash = self.hasher.hash_one(&key);
         self.entries
             .entry(hash, |entry| entry.key.eq(&key), |entry| entry.hash)
@@ -95,6 +112,7 @@ where
                     cell: OnceCell::new(),
                 })
             })
+            .into_mut()
     }
 
     pub fn get<Q>(&self, key: &Q) -> Option<&Arc<OnceTableEntry<K, V>>>

--- a/mea/src/internal/once_table.rs
+++ b/mea/src/internal/once_table.rs
@@ -120,29 +120,19 @@ where
         Some(entry)
     }
 
-    /// Removes the entry only if the table still contains the same allocation.
-    pub fn remove_exact(&mut self, expected: &Arc<OnceTableEntry<K, V>>) -> bool {
-        let Ok(entry) = self
+    /// Removes the entry if the table still contains the same allocation.
+    pub fn remove_entry(&mut self, entry: &Arc<OnceTableEntry<K, V>>) {
+        let Ok(occupied) = self
             .entries
-            .find_entry(expected.hash, |entry| Arc::ptr_eq(entry, expected))
+            .find_entry(entry.hash, |existing| Arc::ptr_eq(existing, entry))
         else {
-            return false;
+            return;
         };
 
-        drop(entry.remove());
-        true
+        drop(occupied.remove());
     }
 
-    pub fn remove_abandoned(&mut self, entry: &Arc<OnceTableEntry<K, V>>) {
-        // If the table still owns this entry, a count of two means the current call is its only
-        // owner outside the table. remove_exact also rejects an entry that was detached or
-        // replaced.
-        if Arc::strong_count(entry) == 2 && !entry.cell.initialized() {
-            self.remove_exact(entry);
-        }
-    }
-
-    pub fn insert_value(&mut self, key: K, value: V) {
+    pub fn insert(&mut self, key: K, value: V) {
         self.remove(&key);
 
         let hash = self.hasher.hash_one(&key);

--- a/mea/src/internal/once_table.rs
+++ b/mea/src/internal/once_table.rs
@@ -12,12 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Shared storage for keyed once primitives.
-//!
-//! Keeping the key and cell in one `Arc` lets calls retain an entry's identity without requiring
-//! `K: Clone`. `HashTable` provides hashed lookup with a custom equality check, preserving borrowed
-//! key lookups and expected O(1) removal of an exact entry.
-
 use std::borrow::Borrow;
 use std::fmt;
 use std::hash::BuildHasher;
@@ -25,27 +19,29 @@ use std::hash::Hash;
 use std::sync::Arc;
 
 use hashbrown::HashTable;
+use hashbrown::hash_table::OccupiedEntry;
 
 use crate::once::OnceCell;
 
-pub(crate) struct KeyedOnceEntry<K, V> {
+pub struct OnceTableEntry<K, V> {
     hash: u64,
     key: K,
     cell: OnceCell<V>,
 }
 
-impl<K, V> KeyedOnceEntry<K, V> {
-    pub(crate) fn cell(&self) -> &OnceCell<V> {
+impl<K, V> OnceTableEntry<K, V> {
+    pub fn cell(&self) -> &OnceCell<V> {
         &self.cell
     }
 }
 
-pub(crate) struct KeyedOnceTable<K, V, S> {
-    entries: HashTable<Arc<KeyedOnceEntry<K, V>>>,
-    hash_builder: S,
+/// Shared keyed storage that lets once primitives clean up an exact entry without cloning its key.
+pub struct OnceTable<K, V, S> {
+    entries: HashTable<Arc<OnceTableEntry<K, V>>>,
+    hasher: S,
 }
 
-impl<K, V, S> fmt::Debug for KeyedOnceTable<K, V, S>
+impl<K, V, S> fmt::Debug for OnceTable<K, V, S>
 where
     K: fmt::Debug,
     V: fmt::Debug,
@@ -57,66 +53,65 @@ where
     }
 }
 
-impl<K, V, S> KeyedOnceTable<K, V, S> {
-    pub(crate) fn with_hasher(hash_builder: S) -> Self {
+impl<K, V, S> OnceTable<K, V, S> {
+    pub fn with_hasher(hasher: S) -> Self {
         Self {
             entries: HashTable::new(),
-            hash_builder,
+            hasher,
         }
     }
 
-    pub(crate) fn with_capacity_and_hasher(capacity: usize, hash_builder: S) -> Self {
+    pub fn with_capacity_and_hasher(capacity: usize, hasher: S) -> Self {
         Self {
             entries: HashTable::with_capacity(capacity),
-            hash_builder,
+            hasher,
         }
     }
 
     #[cfg(test)]
-    pub(crate) fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.entries.len()
     }
 
     #[cfg(test)]
-    pub(crate) fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
 }
 
-impl<K, V, S> KeyedOnceTable<K, V, S>
+impl<K, V, S> OnceTable<K, V, S>
 where
     K: Eq + Hash,
     S: BuildHasher,
 {
-    pub(crate) fn get_or_insert(&mut self, key: K) -> &Arc<KeyedOnceEntry<K, V>> {
-        let hash = self.hash_builder.hash_one(&key);
+    pub fn get_or_insert(&mut self, key: K) -> OccupiedEntry<'_, Arc<OnceTableEntry<K, V>>> {
+        let hash = self.hasher.hash_one(&key);
         self.entries
             .entry(hash, |entry| entry.key.eq(&key), |entry| entry.hash)
             .or_insert_with(|| {
-                Arc::new(KeyedOnceEntry {
+                Arc::new(OnceTableEntry {
                     hash,
                     key,
                     cell: OnceCell::new(),
                 })
             })
-            .into_mut()
     }
 
-    pub(crate) fn get<Q>(&self, key: &Q) -> Option<&Arc<KeyedOnceEntry<K, V>>>
+    pub fn get<Q>(&self, key: &Q) -> Option<&Arc<OnceTableEntry<K, V>>>
     where
         K: Borrow<Q>,
         Q: Eq + Hash + ?Sized,
     {
-        let hash = self.hash_builder.hash_one(key);
+        let hash = self.hasher.hash_one(key);
         self.entries.find(hash, |entry| entry.key.borrow() == key)
     }
 
-    pub(crate) fn remove<Q>(&mut self, key: &Q) -> Option<Arc<KeyedOnceEntry<K, V>>>
+    pub fn remove<Q>(&mut self, key: &Q) -> Option<Arc<OnceTableEntry<K, V>>>
     where
         K: Borrow<Q>,
         Q: Eq + Hash + ?Sized,
     {
-        let hash = self.hash_builder.hash_one(key);
+        let hash = self.hasher.hash_one(key);
         let entry = self
             .entries
             .find_entry(hash, |entry| entry.key.borrow() == key)
@@ -126,7 +121,7 @@ where
     }
 
     /// Removes the entry only if the table still contains the same allocation.
-    pub(crate) fn remove_exact(&mut self, expected: &Arc<KeyedOnceEntry<K, V>>) -> bool {
+    pub fn remove_exact(&mut self, expected: &Arc<OnceTableEntry<K, V>>) -> bool {
         let Ok(entry) = self
             .entries
             .find_entry(expected.hash, |entry| Arc::ptr_eq(entry, expected))
@@ -138,20 +133,20 @@ where
         true
     }
 
-    pub(crate) fn remove_abandoned(&mut self, entry: &Arc<KeyedOnceEntry<K, V>>) {
+    pub fn remove_abandoned(&mut self, entry: &Arc<OnceTableEntry<K, V>>) {
         // If the table still owns this entry, a count of two means the current call is its only
         // owner outside the table. remove_exact also rejects an entry that was detached or
         // replaced.
-        if Arc::strong_count(entry) == 2 && entry.cell.get().is_none() {
+        if Arc::strong_count(entry) == 2 && !entry.cell.initialized() {
             self.remove_exact(entry);
         }
     }
 
-    pub(crate) fn insert_value(&mut self, key: K, value: V) {
+    pub fn insert_value(&mut self, key: K, value: V) {
         self.remove(&key);
 
-        let hash = self.hash_builder.hash_one(&key);
-        let entry = Arc::new(KeyedOnceEntry {
+        let hash = self.hasher.hash_one(&key);
+        let entry = Arc::new(OnceTableEntry {
             hash,
             key,
             cell: OnceCell::from_value(value),

--- a/mea/src/lib.rs
+++ b/mea/src/lib.rs
@@ -99,6 +99,14 @@ fn test_runtime() -> &'static tokio::runtime::Runtime {
 }
 
 #[cfg(test)]
+pub(crate) fn poll_once<F: std::future::Future>(
+    future: std::pin::Pin<&mut F>,
+) -> std::task::Poll<F::Output> {
+    let mut context = std::task::Context::from_waker(std::task::Waker::noop());
+    future.poll(&mut context)
+}
+
+#[cfg(test)]
 mod tests {
     use crate::admission::FairShare;
     use crate::admission::FairSharePermit;

--- a/mea/src/once/once_cell/mod.rs
+++ b/mea/src/once/once_cell/mod.rs
@@ -91,7 +91,7 @@ impl<T> OnceCell<T> {
     }
 
     /// Returns whether the internal value is set.
-    fn initialized_mut(&mut self) -> bool {
+    pub(crate) fn initialized_mut(&mut self) -> bool {
         *self.value_set.get_mut()
     }
 

--- a/mea/src/once/once_cell/mod.rs
+++ b/mea/src/once/once_cell/mod.rs
@@ -86,7 +86,7 @@ impl<T> OnceCell<T> {
     }
 
     /// Returns whether the internal value is set.
-    fn initialized(&self) -> bool {
+    pub(crate) fn initialized(&self) -> bool {
         self.value_set.load(Ordering::Acquire)
     }
 

--- a/mea/src/once/once_map/mod.rs
+++ b/mea/src/once/once_map/mod.rs
@@ -49,14 +49,7 @@ where
     K: Eq + Hash,
     S: BuildHasher,
 {
-    fn new(once_map: &'a OnceMap<K, V, S>, key: K) -> Self {
-        let cell = {
-            let mut map = once_map.map.lock();
-            map.entry(key)
-                .or_insert_with(|| Arc::new(OnceCell::new()))
-                .clone()
-        };
-
+    fn new(once_map: &'a OnceMap<K, V, S>, cell: Arc<OnceCell<V>>) -> Self {
         Self {
             once_map,
             cell: Some(cell),
@@ -150,6 +143,13 @@ where
         }
     }
 
+    fn get_or_insert_cell(&self, key: K) -> Arc<OnceCell<V>> {
+        let mut map = self.map.lock();
+        map.entry(key)
+            .or_insert_with(|| Arc::new(OnceCell::new()))
+            .clone()
+    }
+
     /// Compute the value for the given key if absent.
     ///
     /// If the value for the key is already being computed by another task, this task will wait for
@@ -161,7 +161,12 @@ where
     where
         F: AsyncFnOnce() -> V,
     {
-        let mut guard = ComputeCleanupGuard::new(self, key);
+        let cell = self.get_or_insert_cell(key);
+        if let Some(value) = cell.get() {
+            return value.clone();
+        }
+
+        let mut guard = ComputeCleanupGuard::new(self, cell);
         let result = guard.cell().get_or_init(func).await.clone();
         guard.disarm_cleanup();
         result
@@ -178,7 +183,12 @@ where
     where
         F: AsyncFnOnce() -> Result<V, E>,
     {
-        let mut guard = ComputeCleanupGuard::new(self, key);
+        let cell = self.get_or_insert_cell(key);
+        if let Some(value) = cell.get() {
+            return Ok(value.clone());
+        }
+
+        let mut guard = ComputeCleanupGuard::new(self, cell);
         let result = guard.cell().get_or_try_init(func).await?.clone();
         guard.disarm_cleanup();
         Ok(result)

--- a/mea/src/once/once_map/mod.rs
+++ b/mea/src/once/once_map/mod.rs
@@ -34,6 +34,80 @@ pub struct OnceMap<K, V, S = RandomState> {
     map: Mutex<HashMap<K, Arc<OnceCell<V>>, S>>,
 }
 
+// Holds one call's cell reference so Drop can clean up an abandoned entry.
+struct ComputeCleanupGuard<'a, K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    once_map: &'a OnceMap<K, V, S>,
+    cell: Option<Arc<OnceCell<V>>>,
+}
+
+impl<'a, K, V, S> ComputeCleanupGuard<'a, K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    fn new(once_map: &'a OnceMap<K, V, S>, key: K) -> Self {
+        let cell = {
+            let mut map = once_map.map.lock();
+            map.entry(key)
+                .or_insert_with(|| Arc::new(OnceCell::new()))
+                .clone()
+        };
+
+        Self {
+            once_map,
+            cell: Some(cell),
+        }
+    }
+
+    fn cell(&self) -> &OnceCell<V> {
+        self.cell.as_deref().unwrap()
+    }
+
+    fn disarm_cleanup(&mut self) {
+        drop(self.cell.take());
+    }
+}
+
+impl<K, V, S> Drop for ComputeCleanupGuard<'_, K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    fn drop(&mut self) {
+        let Some(cell) = self.cell.take() else {
+            return;
+        };
+        if cell.get().is_some() {
+            return;
+        }
+
+        let cell_ptr = Arc::as_ptr(&cell);
+        let mut map = self.once_map.map.lock();
+
+        // The map and each current call own one strong reference. With the map locked, a count of
+        // two means this may be the last call using the mapped cell. Other counts mean that another
+        // call can still retry the cell, or that the entry has already been explicitly removed.
+        let may_be_last_call = Arc::strong_count(&cell) == 2;
+        drop(cell);
+        if !may_be_last_call {
+            return;
+        }
+
+        // OnceMap intentionally does not require K: Clone, so locate the cell by allocation
+        // identity. This scan only runs when the last caller leaves a cell uninitialized.
+        map.retain(|_, existing| {
+            let should_remove = Arc::as_ptr(existing) == cell_ptr
+                && Arc::strong_count(existing) == 1
+                && existing.get().is_none();
+            !should_remove
+        });
+    }
+}
+
 impl<K, V, S> Default for OnceMap<K, V, S>
 where
     K: Eq + Hash,
@@ -89,22 +163,17 @@ where
     ///
     /// If the value for the key is already being computed by another task, this task will wait for
     /// the computation to finish and return the result.
+    ///
+    /// If the computation is cancelled or panics, another current caller may retry it. The empty
+    /// entry is removed once no current callers remain.
     pub async fn compute<F>(&self, key: K, func: F) -> V
     where
         F: AsyncFnOnce() -> V,
     {
-        // 1. Get or create the OnceCell.
-        let cell = {
-            let mut map = self.map.lock();
-            map.entry(key)
-                .or_insert_with(|| Arc::new(OnceCell::new()))
-                .clone()
-        };
-
-        // 2. Try to initialize the cell.
-        // OnceCell::get_or_init guarantees that only one task executes the closure.
-        let res = cell.get_or_init(func).await;
-        res.clone()
+        let mut guard = ComputeCleanupGuard::new(self, key);
+        let result = guard.cell().get_or_init(func).await.clone();
+        guard.disarm_cleanup();
+        result
     }
 
     /// Compute the value for the given key if absent.
@@ -112,24 +181,17 @@ where
     /// If the value for the key is already being computed by another task, this task will wait for
     /// the computation to finish and return the result.
     ///
-    /// If the computation fails, the error is returned and the value is not stored. Other tasks
-    /// waiting for the value will retry the computation.
+    /// If the computation fails, is cancelled or panics, the value is not stored and other current
+    /// callers may retry the computation. The empty entry is removed once no current callers
+    /// remain.
     pub async fn try_compute<E, F>(&self, key: K, func: F) -> Result<V, E>
     where
         F: AsyncFnOnce() -> Result<V, E>,
     {
-        // 1. Get or create the OnceCell.
-        let cell = {
-            let mut map = self.map.lock();
-            map.entry(key)
-                .or_insert_with(|| Arc::new(OnceCell::new()))
-                .clone()
-        };
-
-        // 2. Try to initialize the cell.
-        // OnceCell::get_or_try_init guarantees that only one task executes the closure.
-        let res = cell.get_or_try_init(func).await?;
-        Ok(res.clone())
+        let mut guard = ComputeCleanupGuard::new(self, key);
+        let result = guard.cell().get_or_try_init(func).await?.clone();
+        guard.disarm_cleanup();
+        Ok(result)
     }
 
     /// Get a clone of the value for the given key if exists.

--- a/mea/src/once/once_map/mod.rs
+++ b/mea/src/once/once_map/mod.rs
@@ -21,7 +21,6 @@ use std::sync::Arc;
 use crate::internal::Mutex;
 use crate::internal::OnceTable;
 use crate::internal::OnceTableEntry;
-use crate::once::OnceCell;
 
 #[cfg(test)]
 mod tests;
@@ -57,8 +56,8 @@ where
         }
     }
 
-    fn cell(&self) -> &OnceCell<V> {
-        self.entry.as_deref().unwrap().cell()
+    fn entry(&self) -> &Arc<OnceTableEntry<K, V>> {
+        self.entry.as_ref().unwrap()
     }
 
     fn dismiss(mut self) {
@@ -75,13 +74,15 @@ where
         let Some(entry) = self.entry.take() else {
             return;
         };
-        if entry.cell().initialized() {
-            return;
-        }
 
-        let mut map = self.once_map.map.lock();
-        map.remove_abandoned(&entry);
-        // Let another cleanup waiting for the map observe the updated reference count.
+        let mut table = self.once_map.map.lock();
+        // If the table still owns this entry, a count of two means the current call is its only
+        // owner outside the table. remove_entry rejects an entry that was detached or replaced.
+        if Arc::strong_count(&entry) == 2 && !entry.cell().initialized() {
+            table.remove_entry(&entry);
+        }
+        // Drop this call's reference before unlocking so a waiting cleanup observes the updated
+        // reference count.
         drop(entry);
     }
 }
@@ -161,7 +162,7 @@ where
         };
 
         let guard = ComputeCleanupGuard::new(self, entry);
-        let result = guard.cell().get_or_init(func).await.clone();
+        let result = guard.entry().cell().get_or_init(func).await.clone();
         guard.dismiss();
         result
     }
@@ -187,7 +188,7 @@ where
         };
 
         let guard = ComputeCleanupGuard::new(self, entry);
-        let result = guard.cell().get_or_try_init(func).await?.clone();
+        let result = guard.entry().cell().get_or_try_init(func).await?.clone();
         guard.dismiss();
         Ok(result)
     }
@@ -242,7 +243,7 @@ where
     fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
         let mut map = OnceTable::with_hasher(S::default());
         for (key, value) in iter {
-            map.insert_value(key, value);
+            map.insert(key, value);
         }
 
         Self {

--- a/mea/src/once/once_map/mod.rs
+++ b/mea/src/once/once_map/mod.rs
@@ -18,9 +18,9 @@ use std::hash::Hash;
 use std::hash::RandomState;
 use std::sync::Arc;
 
-use crate::internal::KeyedOnceEntry;
-use crate::internal::KeyedOnceTable;
 use crate::internal::Mutex;
+use crate::internal::OnceTable;
+use crate::internal::OnceTableEntry;
 use crate::once::OnceCell;
 
 #[cfg(test)]
@@ -32,12 +32,7 @@ mod tests;
 /// to wrap the `V` in an `Arc<V>` to make cloning cheap.
 #[derive(Debug)]
 pub struct OnceMap<K, V, S = RandomState> {
-    map: Mutex<KeyedOnceTable<K, V, S>>,
-}
-
-enum ComputeState<K, V> {
-    Cached(V),
-    Uninitialized(Arc<KeyedOnceEntry<K, V>>),
+    map: Mutex<OnceTable<K, V, S>>,
 }
 
 // Holds one call's entry so Drop can clean it up if the computation is abandoned.
@@ -47,7 +42,7 @@ where
     S: BuildHasher,
 {
     once_map: &'a OnceMap<K, V, S>,
-    entry: Option<Arc<KeyedOnceEntry<K, V>>>,
+    entry: Option<Arc<OnceTableEntry<K, V>>>,
 }
 
 impl<'a, K, V, S> ComputeCleanupGuard<'a, K, V, S>
@@ -55,7 +50,7 @@ where
     K: Eq + Hash,
     S: BuildHasher,
 {
-    fn new(once_map: &'a OnceMap<K, V, S>, entry: Arc<KeyedOnceEntry<K, V>>) -> Self {
+    fn new(once_map: &'a OnceMap<K, V, S>, entry: Arc<OnceTableEntry<K, V>>) -> Self {
         Self {
             once_map,
             entry: Some(entry),
@@ -66,7 +61,7 @@ where
         self.entry.as_deref().unwrap().cell()
     }
 
-    fn disarm_cleanup(&mut self) {
+    fn dismiss(mut self) {
         drop(self.entry.take());
     }
 }
@@ -80,7 +75,7 @@ where
         let Some(entry) = self.entry.take() else {
             return;
         };
-        if entry.cell().get().is_some() {
+        if entry.cell().initialized() {
             return;
         }
 
@@ -110,14 +105,14 @@ where
     /// Creates a new OnceMap with the default hasher.
     pub fn new() -> Self {
         Self {
-            map: Mutex::new(KeyedOnceTable::with_hasher(RandomState::new())),
+            map: Mutex::new(OnceTable::with_hasher(RandomState::new())),
         }
     }
 
     /// Creates a new OnceMap with the default hasher and the specified capacity.
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            map: Mutex::new(KeyedOnceTable::with_capacity_and_hasher(
+            map: Mutex::new(OnceTable::with_capacity_and_hasher(
                 capacity,
                 RandomState::new(),
             )),
@@ -134,23 +129,14 @@ where
     /// Creates a new OnceMap with the given hasher.
     pub fn with_hasher(hasher: S) -> Self {
         Self {
-            map: Mutex::new(KeyedOnceTable::with_hasher(hasher)),
+            map: Mutex::new(OnceTable::with_hasher(hasher)),
         }
     }
 
     /// Create a OnceMap with the specified capacity and hasher.
     pub fn with_capacity_and_hasher(capacity: usize, hasher: S) -> Self {
         Self {
-            map: Mutex::new(KeyedOnceTable::with_capacity_and_hasher(capacity, hasher)),
-        }
-    }
-
-    fn entry_state(&self, key: K) -> ComputeState<K, V> {
-        let mut map = self.map.lock();
-        let entry = map.get_or_insert(key);
-        match entry.cell().get() {
-            Some(value) => ComputeState::Cached(value.clone()),
-            None => ComputeState::Uninitialized(Arc::clone(entry)),
+            map: Mutex::new(OnceTable::with_capacity_and_hasher(capacity, hasher)),
         }
     }
 
@@ -165,14 +151,18 @@ where
     where
         F: AsyncFnOnce() -> V,
     {
-        let entry = match self.entry_state(key) {
-            ComputeState::Cached(value) => return value,
-            ComputeState::Uninitialized(entry) => entry,
+        let entry = {
+            let mut map = self.map.lock();
+            let entry = map.get_or_insert(key);
+            if let Some(value) = entry.get().cell().get() {
+                return value.clone();
+            }
+            Arc::clone(entry.get())
         };
 
-        let mut guard = ComputeCleanupGuard::new(self, entry);
+        let guard = ComputeCleanupGuard::new(self, entry);
         let result = guard.cell().get_or_init(func).await.clone();
-        guard.disarm_cleanup();
+        guard.dismiss();
         result
     }
 
@@ -187,14 +177,18 @@ where
     where
         F: AsyncFnOnce() -> Result<V, E>,
     {
-        let entry = match self.entry_state(key) {
-            ComputeState::Cached(value) => return Ok(value),
-            ComputeState::Uninitialized(entry) => entry,
+        let entry = {
+            let mut map = self.map.lock();
+            let entry = map.get_or_insert(key);
+            if let Some(value) = entry.get().cell().get() {
+                return Ok(value.clone());
+            }
+            Arc::clone(entry.get())
         };
 
-        let mut guard = ComputeCleanupGuard::new(self, entry);
+        let guard = ComputeCleanupGuard::new(self, entry);
         let result = guard.cell().get_or_try_init(func).await?.clone();
-        guard.disarm_cleanup();
+        guard.dismiss();
         Ok(result)
     }
 
@@ -246,7 +240,7 @@ where
     S: Default + BuildHasher,
 {
     fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
-        let mut map = KeyedOnceTable::with_hasher(S::default());
+        let mut map = OnceTable::with_hasher(S::default());
         for (key, value) in iter {
             map.insert_value(key, value);
         }

--- a/mea/src/once/once_map/mod.rs
+++ b/mea/src/once/once_map/mod.rs
@@ -13,12 +13,13 @@
 // limitations under the License.
 
 use std::borrow::Borrow;
-use std::collections::HashMap;
 use std::hash::BuildHasher;
 use std::hash::Hash;
 use std::hash::RandomState;
 use std::sync::Arc;
 
+use crate::internal::KeyedOnceEntry;
+use crate::internal::KeyedOnceTable;
 use crate::internal::Mutex;
 use crate::once::OnceCell;
 
@@ -31,17 +32,22 @@ mod tests;
 /// to wrap the `V` in an `Arc<V>` to make cloning cheap.
 #[derive(Debug)]
 pub struct OnceMap<K, V, S = RandomState> {
-    map: Mutex<HashMap<K, Arc<OnceCell<V>>, S>>,
+    map: Mutex<KeyedOnceTable<K, V, S>>,
 }
 
-// Holds one call's cell reference so Drop can clean up an abandoned entry.
+enum ComputeState<K, V> {
+    Cached(V),
+    Uninitialized(Arc<KeyedOnceEntry<K, V>>),
+}
+
+// Holds one call's entry so Drop can clean it up if the computation is abandoned.
 struct ComputeCleanupGuard<'a, K, V, S>
 where
     K: Eq + Hash,
     S: BuildHasher,
 {
     once_map: &'a OnceMap<K, V, S>,
-    cell: Option<Arc<OnceCell<V>>>,
+    entry: Option<Arc<KeyedOnceEntry<K, V>>>,
 }
 
 impl<'a, K, V, S> ComputeCleanupGuard<'a, K, V, S>
@@ -49,19 +55,19 @@ where
     K: Eq + Hash,
     S: BuildHasher,
 {
-    fn new(once_map: &'a OnceMap<K, V, S>, cell: Arc<OnceCell<V>>) -> Self {
+    fn new(once_map: &'a OnceMap<K, V, S>, entry: Arc<KeyedOnceEntry<K, V>>) -> Self {
         Self {
             once_map,
-            cell: Some(cell),
+            entry: Some(entry),
         }
     }
 
     fn cell(&self) -> &OnceCell<V> {
-        self.cell.as_deref().unwrap()
+        self.entry.as_deref().unwrap().cell()
     }
 
     fn disarm_cleanup(&mut self) {
-        drop(self.cell.take());
+        drop(self.entry.take());
     }
 }
 
@@ -71,24 +77,17 @@ where
     S: BuildHasher,
 {
     fn drop(&mut self) {
-        let Some(cell) = self.cell.take() else {
+        let Some(entry) = self.entry.take() else {
             return;
         };
-        if cell.get().is_some() {
+        if entry.cell().get().is_some() {
             return;
         }
 
         let mut map = self.once_map.map.lock();
-
-        // The map and each current call own one strong reference. If the map still points to this
-        // cell, a count of two means only the map and this last call own it. Drop this call's
-        // reference before unlocking so a waiting cleanup observes the updated count.
-        if Arc::strong_count(&cell) == 2 {
-            // OnceMap intentionally does not require K: Clone, so locate the cell by allocation
-            // identity. This scan only runs when the last call leaves a cell uninitialized.
-            map.retain(|_, existing| !Arc::ptr_eq(existing, &cell) || existing.get().is_some());
-        }
-        drop(cell);
+        map.remove_abandoned(&entry);
+        // Let another cleanup waiting for the map observe the updated reference count.
+        drop(entry);
     }
 }
 
@@ -96,7 +95,7 @@ impl<K, V, S> Default for OnceMap<K, V, S>
 where
     K: Eq + Hash,
     V: Clone,
-    S: BuildHasher + Clone + Default,
+    S: BuildHasher + Default,
 {
     fn default() -> Self {
         Self::with_hasher(S::default())
@@ -111,14 +110,17 @@ where
     /// Creates a new OnceMap with the default hasher.
     pub fn new() -> Self {
         Self {
-            map: Mutex::new(HashMap::new()),
+            map: Mutex::new(KeyedOnceTable::with_hasher(RandomState::new())),
         }
     }
 
     /// Creates a new OnceMap with the default hasher and the specified capacity.
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            map: Mutex::new(HashMap::with_capacity(capacity)),
+            map: Mutex::new(KeyedOnceTable::with_capacity_and_hasher(
+                capacity,
+                RandomState::new(),
+            )),
         }
     }
 }
@@ -127,27 +129,29 @@ impl<K, V, S> OnceMap<K, V, S>
 where
     K: Eq + Hash,
     V: Clone,
-    S: BuildHasher + Clone,
+    S: BuildHasher,
 {
     /// Creates a new OnceMap with the given hasher.
     pub fn with_hasher(hasher: S) -> Self {
         Self {
-            map: Mutex::new(HashMap::with_hasher(hasher)),
+            map: Mutex::new(KeyedOnceTable::with_hasher(hasher)),
         }
     }
 
     /// Create a OnceMap with the specified capacity and hasher.
     pub fn with_capacity_and_hasher(capacity: usize, hasher: S) -> Self {
         Self {
-            map: Mutex::new(HashMap::with_capacity_and_hasher(capacity, hasher)),
+            map: Mutex::new(KeyedOnceTable::with_capacity_and_hasher(capacity, hasher)),
         }
     }
 
-    fn get_or_insert_cell(&self, key: K) -> Arc<OnceCell<V>> {
+    fn entry_state(&self, key: K) -> ComputeState<K, V> {
         let mut map = self.map.lock();
-        map.entry(key)
-            .or_insert_with(|| Arc::new(OnceCell::new()))
-            .clone()
+        let entry = map.get_or_insert(key);
+        match entry.cell().get() {
+            Some(value) => ComputeState::Cached(value.clone()),
+            None => ComputeState::Uninitialized(Arc::clone(entry)),
+        }
     }
 
     /// Compute the value for the given key if absent.
@@ -161,12 +165,12 @@ where
     where
         F: AsyncFnOnce() -> V,
     {
-        let cell = self.get_or_insert_cell(key);
-        if let Some(value) = cell.get() {
-            return value.clone();
-        }
+        let entry = match self.entry_state(key) {
+            ComputeState::Cached(value) => return value,
+            ComputeState::Uninitialized(entry) => entry,
+        };
 
-        let mut guard = ComputeCleanupGuard::new(self, cell);
+        let mut guard = ComputeCleanupGuard::new(self, entry);
         let result = guard.cell().get_or_init(func).await.clone();
         guard.disarm_cleanup();
         result
@@ -183,12 +187,12 @@ where
     where
         F: AsyncFnOnce() -> Result<V, E>,
     {
-        let cell = self.get_or_insert_cell(key);
-        if let Some(value) = cell.get() {
-            return Ok(value.clone());
-        }
+        let entry = match self.entry_state(key) {
+            ComputeState::Cached(value) => return Ok(value),
+            ComputeState::Uninitialized(entry) => entry,
+        };
 
-        let mut guard = ComputeCleanupGuard::new(self, cell);
+        let mut guard = ComputeCleanupGuard::new(self, entry);
         let result = guard.cell().get_or_try_init(func).await?.clone();
         guard.disarm_cleanup();
         Ok(result)
@@ -201,8 +205,8 @@ where
         Q: Hash + Eq + ?Sized,
     {
         let map = self.map.lock();
-        let cell = map.get(key)?;
-        cell.get().cloned()
+        let entry = map.get(key)?;
+        entry.cell().get().cloned()
     }
 
     /// Remove the given key from the map.
@@ -230,24 +234,25 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let cell = self.map.lock().remove(key)?;
-        cell.get().cloned()
+        let entry = self.map.lock().remove(key)?;
+        entry.cell().get().cloned()
     }
 }
 
 impl<K, V, S> FromIterator<(K, V)> for OnceMap<K, V, S>
 where
-    K: Eq + Hash + Clone,
+    K: Eq + Hash,
     V: Clone,
-    S: Default + BuildHasher + Clone,
+    S: Default + BuildHasher,
 {
     fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
+        let mut map = KeyedOnceTable::with_hasher(S::default());
+        for (key, value) in iter {
+            map.insert_value(key, value);
+        }
+
         Self {
-            map: Mutex::new(
-                iter.into_iter()
-                    .map(|(k, v)| (k, Arc::new(OnceCell::from_value(v))))
-                    .collect(),
-            ),
+            map: Mutex::new(map),
         }
     }
 }

--- a/mea/src/once/once_map/mod.rs
+++ b/mea/src/once/once_map/mod.rs
@@ -85,26 +85,17 @@ where
             return;
         }
 
-        let cell_ptr = Arc::as_ptr(&cell);
         let mut map = self.once_map.map.lock();
 
-        // The map and each current call own one strong reference. With the map locked, a count of
-        // two means this may be the last call using the mapped cell. Other counts mean that another
-        // call can still retry the cell, or that the entry has already been explicitly removed.
-        let may_be_last_call = Arc::strong_count(&cell) == 2;
-        drop(cell);
-        if !may_be_last_call {
-            return;
+        // The map and each current call own one strong reference. If the map still points to this
+        // cell, a count of two means only the map and this last call own it. Drop this call's
+        // reference before unlocking so a waiting cleanup observes the updated count.
+        if Arc::strong_count(&cell) == 2 {
+            // OnceMap intentionally does not require K: Clone, so locate the cell by allocation
+            // identity. This scan only runs when the last call leaves a cell uninitialized.
+            map.retain(|_, existing| !Arc::ptr_eq(existing, &cell) || existing.get().is_some());
         }
-
-        // OnceMap intentionally does not require K: Clone, so locate the cell by allocation
-        // identity. This scan only runs when the last caller leaves a cell uninitialized.
-        map.retain(|_, existing| {
-            let should_remove = Arc::as_ptr(existing) == cell_ptr
-                && Arc::strong_count(existing) == 1
-                && existing.get().is_none();
-            !should_remove
-        });
+        drop(cell);
     }
 }
 
@@ -164,8 +155,8 @@ where
     /// If the value for the key is already being computed by another task, this task will wait for
     /// the computation to finish and return the result.
     ///
-    /// If the computation is cancelled or panics, another current caller may retry it. The empty
-    /// entry is removed once no current callers remain.
+    /// If the computation is cancelled or panics, another caller waiting for the same key may retry
+    /// it.
     pub async fn compute<F>(&self, key: K, func: F) -> V
     where
         F: AsyncFnOnce() -> V,
@@ -181,9 +172,8 @@ where
     /// If the value for the key is already being computed by another task, this task will wait for
     /// the computation to finish and return the result.
     ///
-    /// If the computation fails, is cancelled or panics, the value is not stored and other current
-    /// callers may retry the computation. The empty entry is removed once no current callers
-    /// remain.
+    /// If the computation returns an error, it is returned to that caller and the value is not
+    /// stored. After an error, cancellation, or panic, another caller may retry the computation.
     pub async fn try_compute<E, F>(&self, key: K, func: F) -> Result<V, E>
     where
         F: AsyncFnOnce() -> Result<V, E>,

--- a/mea/src/once/once_map/mod.rs
+++ b/mea/src/once/once_map/mod.rs
@@ -78,7 +78,7 @@ where
         let mut table = self.once_map.map.lock();
         // If the table still owns this entry, a count of two means the current call is its only
         // owner outside the table. remove_entry rejects an entry that was detached or replaced.
-        if Arc::strong_count(&entry) == 2 && !entry.cell().initialized() {
+        if Arc::strong_count(&entry) == 2 && !entry.initialized() {
             table.remove_entry(&entry);
         }
         // Drop this call's reference before unlocking so a waiting cleanup observes the updated
@@ -155,14 +155,14 @@ where
         let entry = {
             let mut map = self.map.lock();
             let entry = map.get_or_insert(key);
-            if let Some(value) = entry.get().cell().get() {
+            if let Some(value) = entry.get() {
                 return value.clone();
             }
-            Arc::clone(entry.get())
+            Arc::clone(entry)
         };
 
         let guard = ComputeCleanupGuard::new(self, entry);
-        let result = guard.entry().cell().get_or_init(func).await.clone();
+        let result = guard.entry().get_or_init(func).await.clone();
         guard.dismiss();
         result
     }
@@ -181,14 +181,14 @@ where
         let entry = {
             let mut map = self.map.lock();
             let entry = map.get_or_insert(key);
-            if let Some(value) = entry.get().cell().get() {
+            if let Some(value) = entry.get() {
                 return Ok(value.clone());
             }
-            Arc::clone(entry.get())
+            Arc::clone(entry)
         };
 
         let guard = ComputeCleanupGuard::new(self, entry);
-        let result = guard.entry().cell().get_or_try_init(func).await?.clone();
+        let result = guard.entry().get_or_try_init(func).await?.clone();
         guard.dismiss();
         Ok(result)
     }
@@ -201,7 +201,7 @@ where
     {
         let map = self.map.lock();
         let entry = map.get(key)?;
-        entry.cell().get().cloned()
+        entry.get().cloned()
     }
 
     /// Remove the given key from the map.
@@ -230,7 +230,7 @@ where
         Q: Hash + Eq + ?Sized,
     {
         let entry = self.map.lock().remove(key)?;
-        entry.cell().get().cloned()
+        entry.get().cloned()
     }
 }
 

--- a/mea/src/once/once_map/tests.rs
+++ b/mea/src/once/once_map/tests.rs
@@ -13,13 +13,21 @@
 // limitations under the License.
 
 use std::collections::hash_map::RandomState;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
+use std::task::Context;
+use std::task::Poll;
+use std::task::Waker;
 use std::time::Duration;
 
 use crate::once::OnceMap;
+
+fn poll_once<F: Future>(future: Pin<&mut F>) -> Poll<F::Output> {
+    future.poll(&mut Context::from_waker(Waker::noop()))
+}
 
 #[test]
 fn test_default_and_constructors() {
@@ -75,6 +83,7 @@ async fn test_try_compute() {
     // Fail first
     let res: Result<i32, &str> = map.try_compute("key", async || Err("fail")).await;
     assert_eq!(res, Err("fail"));
+    assert!(map.map.lock().is_empty());
 
     // Success then
     let res: Result<i32, &str> = map.try_compute("key", async || Ok::<i32, &str>(1)).await;
@@ -86,42 +95,68 @@ async fn test_try_compute() {
 }
 
 #[tokio::test]
-async fn test_try_compute_concurrent_failure_then_success() {
-    let map = Arc::new(OnceMap::new());
-    let success = Arc::new(AtomicBool::new(false));
+async fn test_panicked_compute_removes_empty_entry() {
+    let map = Arc::new(OnceMap::<&str, i32>::new());
+
     let map_clone = map.clone();
-    let success_clone = success.clone();
-
-    // Spawn a task that fails
-    let t1 = tokio::spawn(async move {
+    let task = tokio::spawn(async move {
         map_clone
-            .try_compute("key", async move || {
-                tokio::time::sleep(Duration::from_millis(50)).await;
-                Err::<i32, _>("fail")
+            .compute("key", async || {
+                panic!("oops");
             })
             .await
     });
 
-    // Spawn a task that succeeds, but starts slightly later/runs concurrent
-    let map_clone2 = map.clone();
-    let t2 = tokio::spawn(async move {
-        // Wait for t1 to start
-        tokio::time::sleep(Duration::from_millis(10)).await;
-        // This should block until t1 fails, then retry (conceptually)
-        map_clone2
-            .try_compute("key", async move || {
-                success_clone.store(true, Ordering::SeqCst);
-                Ok::<i32, &str>(1)
+    assert!(task.await.unwrap_err().is_panic());
+    assert!(map.map.lock().is_empty());
+}
+
+#[tokio::test]
+async fn test_cancelled_compute_removes_empty_entry() {
+    let map = Arc::new(OnceMap::<&str, i32>::new());
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+    let map_clone = map.clone();
+    let task = tokio::spawn(async move {
+        map_clone
+            .compute("key", async move || {
+                started_tx.send(()).unwrap();
+                std::future::pending().await
             })
             .await
     });
 
-    let res1 = t1.await.unwrap();
-    assert_eq!(res1, Err("fail"));
+    started_rx.await.unwrap();
+    assert_eq!(map.map.lock().len(), 1);
 
-    let res2 = t2.await.unwrap();
-    assert_eq!(res2, Ok(1));
-    assert!(success.load(Ordering::SeqCst));
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
+    assert!(map.map.lock().is_empty());
+}
+
+#[tokio::test]
+async fn test_try_compute_concurrent_failure_then_success() {
+    let map = OnceMap::new();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+
+    let first = map.try_compute("key", async move || {
+        release_rx.await.unwrap();
+        Err::<i32, &str>("fail")
+    });
+    tokio::pin!(first);
+    assert!(poll_once(first.as_mut()).is_pending());
+
+    let retry = map.try_compute("key", async || Ok::<i32, &str>(1));
+    tokio::pin!(retry);
+    assert!(poll_once(retry.as_mut()).is_pending());
+
+    release_tx.send(()).unwrap();
+    assert_eq!(first.await, Err("fail"));
+
+    // The failed caller must not remove the cell while an existing waiter can still retry it.
+    assert_eq!(map.map.lock().len(), 1);
+    assert_eq!(retry.await, Ok(1));
+    assert_eq!(map.get("key"), Some(1));
 }
 
 #[tokio::test]
@@ -201,7 +236,7 @@ async fn test_from_iter() {
 
 #[tokio::test]
 async fn test_complex_key_value() {
-    #[derive(Hash, PartialEq, Eq, Clone, Debug)]
+    #[derive(Hash, PartialEq, Eq, Debug)]
     struct Key(i32);
 
     let map = OnceMap::new();

--- a/mea/src/once/once_map/tests.rs
+++ b/mea/src/once/once_map/tests.rs
@@ -13,21 +13,13 @@
 // limitations under the License.
 
 use std::collections::hash_map::RandomState;
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
-use std::task::Context;
-use std::task::Poll;
-use std::task::Waker;
 use std::time::Duration;
 
 use crate::once::OnceMap;
-
-fn poll_once<F: Future>(future: Pin<&mut F>) -> Poll<F::Output> {
-    future.poll(&mut Context::from_waker(Waker::noop()))
-}
+use crate::poll_once;
 
 #[test]
 fn test_default_and_constructors() {

--- a/mea/src/once/once_map/tests.rs
+++ b/mea/src/once/once_map/tests.rs
@@ -153,18 +153,18 @@ async fn test_try_compute_concurrent_failure_then_success() {
 
 #[tokio::test]
 async fn test_get_remove() {
-    let map = OnceMap::new();
+    let map = OnceMap::<String, i32>::new();
     assert_eq!(map.get("key"), None);
     assert_eq!(map.remove("key"), None);
 
-    map.compute("key", async || 1).await;
+    map.compute("key".to_owned(), async || 1).await;
     assert_eq!(map.get("key"), Some(1));
 
     let v = map.remove("key");
     assert_eq!(v, Some(1));
     assert_eq!(map.get("key"), None);
 
-    map.compute("key", async || 2).await;
+    map.compute("key".to_owned(), async || 2).await;
     map.discard("key");
     assert_eq!(map.get("key"), None);
 }
@@ -220,10 +220,15 @@ async fn test_get_while_computing() {
 
 #[tokio::test]
 async fn test_from_iter() {
-    let map: OnceMap<_, _> = vec![("a", 1), ("b", 2)].into_iter().collect();
-    assert_eq!(map.get("a"), Some(1));
-    assert_eq!(map.get("b"), Some(2));
-    assert_eq!(map.get("c"), None);
+    #[derive(Hash, PartialEq, Eq)]
+    struct Key(&'static str);
+
+    let map: OnceMap<_, _> = vec![(Key("a"), 1), (Key("b"), 2), (Key("a"), 3)]
+        .into_iter()
+        .collect();
+    assert_eq!(map.get(&Key("a")), Some(3));
+    assert_eq!(map.get(&Key("b")), Some(2));
+    assert_eq!(map.get(&Key("c")), None);
 }
 
 #[tokio::test]

--- a/mea/src/singleflight/mod.rs
+++ b/mea/src/singleflight/mod.rs
@@ -23,7 +23,6 @@ use std::sync::Arc;
 use crate::internal::Mutex;
 use crate::internal::OnceTable;
 use crate::internal::OnceTableEntry;
-use crate::once::OnceCell;
 
 #[cfg(test)]
 mod tests;
@@ -62,14 +61,8 @@ where
         }
     }
 
-    fn cell(&self) -> &OnceCell<V> {
-        self.entry.as_deref().unwrap().cell()
-    }
-
-    fn remove_completed_entry(&self) {
-        let entry = self.entry.as_ref().unwrap();
-        let mut map = self.group.map.lock();
-        map.remove_exact(entry);
+    fn entry(&self) -> &Arc<OnceTableEntry<K, V>> {
+        self.entry.as_ref().unwrap()
     }
 
     fn dismiss(mut self) {
@@ -86,13 +79,15 @@ where
         let Some(entry) = self.entry.take() else {
             return;
         };
-        if entry.cell().initialized() {
-            return;
-        }
 
-        let mut map = self.group.map.lock();
-        map.remove_abandoned(&entry);
-        // Let another cleanup waiting for the map observe the updated reference count.
+        let mut table = self.group.map.lock();
+        // If the table still owns this entry, a count of two means the current call is its only
+        // owner outside the table. remove_entry rejects an entry that was detached or replaced.
+        if Arc::strong_count(&entry) == 2 && !entry.cell().initialized() {
+            table.remove_entry(&entry);
+        }
+        // Drop this call's reference before unlocking so a waiting cleanup observes the updated
+        // reference count.
         drop(entry);
     }
 }
@@ -192,10 +187,11 @@ where
     {
         let guard = WorkCleanupGuard::new(self, key);
         let result = guard
+            .entry()
             .cell()
             .get_or_init(async || {
                 let result = func().await;
-                guard.remove_completed_entry();
+                self.map.lock().remove_entry(guard.entry());
                 result
             })
             .await
@@ -256,10 +252,11 @@ where
     {
         let guard = WorkCleanupGuard::new(self, key);
         let result = guard
+            .entry()
             .cell()
             .get_or_try_init(async || {
                 let result = func().await?;
-                guard.remove_completed_entry();
+                self.map.lock().remove_entry(guard.entry());
                 Ok(result)
             })
             .await?

--- a/mea/src/singleflight/mod.rs
+++ b/mea/src/singleflight/mod.rs
@@ -52,7 +52,7 @@ where
     fn new(group: &'a Group<K, V, S>, key: K) -> Self {
         let entry = {
             let mut map = group.map.lock();
-            Arc::clone(map.get_or_insert(key).get())
+            Arc::clone(map.get_or_insert(key))
         };
 
         Self {
@@ -83,7 +83,7 @@ where
         let mut table = self.group.map.lock();
         // If the table still owns this entry, a count of two means the current call is its only
         // owner outside the table. remove_entry rejects an entry that was detached or replaced.
-        if Arc::strong_count(&entry) == 2 && !entry.cell().initialized() {
+        if Arc::strong_count(&entry) == 2 && !entry.initialized() {
             table.remove_entry(&entry);
         }
         // Drop this call's reference before unlocking so a waiting cleanup observes the updated
@@ -188,7 +188,6 @@ where
         let guard = WorkCleanupGuard::new(self, key);
         let entry = guard.entry();
         let result = entry
-            .cell()
             .get_or_init(async || {
                 let result = func().await;
                 self.map.lock().remove_entry(entry);
@@ -253,7 +252,6 @@ where
         let guard = WorkCleanupGuard::new(self, key);
         let entry = guard.entry();
         let result = entry
-            .cell()
             .get_or_try_init(async || {
                 let result = func().await?;
                 self.map.lock().remove_entry(entry);

--- a/mea/src/singleflight/mod.rs
+++ b/mea/src/singleflight/mod.rs
@@ -98,26 +98,19 @@ where
             return;
         }
 
-        let cell_ptr = Arc::as_ptr(&cell);
         let mut map = self.group.map.lock();
 
-        // The map and each current call own one strong reference. With the map locked, a count of
-        // two means this may be the last call using the mapped cell. Other counts mean that another
-        // call can still retry the cell, or that `forget` has already removed it.
-        let may_be_last_call = Arc::strong_count(&cell) == 2;
-        drop(cell);
-        if !may_be_last_call {
-            return;
-        }
-
-        let should_remove = map.get(&self.key).is_some_and(|existing| {
-            cell_ptr == Arc::as_ptr(existing)
-                && Arc::strong_count(existing) == 1
-                && existing.get().is_none()
-        });
+        // The map and each current call own one strong reference. If the map still points to this
+        // cell, a count of two means only the map and this last call own it. Drop this call's
+        // reference before unlocking so a waiting cleanup observes the updated count.
+        let should_remove = Arc::strong_count(&cell) == 2
+            && map
+                .get(&self.key)
+                .is_some_and(|existing| Arc::ptr_eq(&cell, existing) && existing.get().is_none());
         if should_remove {
             map.remove(&self.key);
         }
+        drop(cell);
     }
 }
 
@@ -164,8 +157,8 @@ where
     /// If a duplicate comes in, the duplicate caller waits for the original to complete and
     /// receives the same results.
     ///
-    /// If the computation is cancelled or panics, another current caller may retry it. The empty
-    /// entry is removed once no current callers remain.
+    /// If the computation is cancelled or panics, another caller waiting for the same key may retry
+    /// it.
     ///
     /// Once the function completes, the key, if not [`forgotten`], is removed from the group,
     /// allowing future calls with the same key to execute the function again.
@@ -234,8 +227,8 @@ where
     /// If a duplicate comes in, the duplicate caller waits for the original to complete and
     /// receives the same results.
     ///
-    /// If the computation fails, is cancelled or panics, other current callers may retry it. The
-    /// empty entry is removed once no current callers remain.
+    /// If the computation returns an error, it is returned to that caller. After an error,
+    /// cancellation, or panic, another caller may retry the computation.
     ///
     /// Once the function completes successfully, the key, if not [`forgotten`], is removed from
     /// the group, allowing future calls with the same key to execute the function again.

--- a/mea/src/singleflight/mod.rs
+++ b/mea/src/singleflight/mod.rs
@@ -186,12 +186,12 @@ where
         F: AsyncFnOnce() -> V,
     {
         let guard = WorkCleanupGuard::new(self, key);
-        let result = guard
-            .entry()
+        let entry = guard.entry();
+        let result = entry
             .cell()
             .get_or_init(async || {
                 let result = func().await;
-                self.map.lock().remove_entry(guard.entry());
+                self.map.lock().remove_entry(entry);
                 result
             })
             .await
@@ -251,12 +251,12 @@ where
         F: AsyncFnOnce() -> Result<V, E>,
     {
         let guard = WorkCleanupGuard::new(self, key);
-        let result = guard
-            .entry()
+        let entry = guard.entry();
+        let result = entry
             .cell()
             .get_or_try_init(async || {
                 let result = func().await?;
-                self.map.lock().remove_entry(guard.entry());
+                self.map.lock().remove_entry(entry);
                 Ok(result)
             })
             .await?

--- a/mea/src/singleflight/mod.rs
+++ b/mea/src/singleflight/mod.rs
@@ -15,12 +15,13 @@
 //! Singleflight provides a duplicate function call suppression mechanism.
 
 use std::borrow::Borrow;
-use std::collections::HashMap;
 use std::hash::BuildHasher;
 use std::hash::Hash;
 use std::hash::RandomState;
 use std::sync::Arc;
 
+use crate::internal::KeyedOnceEntry;
+use crate::internal::KeyedOnceTable;
 use crate::internal::Mutex;
 use crate::once::OnceCell;
 
@@ -31,57 +32,48 @@ mod tests;
 /// units of work can be executed with duplicate suppression.
 #[derive(Debug)]
 pub struct Group<K, V, S = RandomState> {
-    map: Mutex<HashMap<K, Arc<OnceCell<V>>, S>>,
+    map: Mutex<KeyedOnceTable<K, V, S>>,
 }
 
-// Holds one call's cell reference so Drop can clean up an abandoned entry.
+// Holds one call's entry so Drop can clean it up if the work is abandoned.
 struct WorkCleanupGuard<'a, K, V, S>
 where
     K: Eq + Hash,
     S: BuildHasher,
 {
     group: &'a Group<K, V, S>,
-    key: K,
-    cell: Option<Arc<OnceCell<V>>>,
+    entry: Option<Arc<KeyedOnceEntry<K, V>>>,
 }
 
 impl<'a, K, V, S> WorkCleanupGuard<'a, K, V, S>
 where
-    K: Eq + Hash + Clone,
+    K: Eq + Hash,
     S: BuildHasher,
 {
     fn new(group: &'a Group<K, V, S>, key: K) -> Self {
-        let cell = {
+        let entry = {
             let mut map = group.map.lock();
-            map.entry(key.clone())
-                .or_insert_with(|| Arc::new(OnceCell::new()))
-                .clone()
+            Arc::clone(map.get_or_insert(key))
         };
 
         Self {
             group,
-            key,
-            cell: Some(cell),
+            entry: Some(entry),
         }
     }
 
     fn cell(&self) -> &OnceCell<V> {
-        self.cell.as_deref().unwrap()
+        self.entry.as_deref().unwrap().cell()
     }
 
     fn remove_completed_entry(&self) {
-        let cell = self.cell.as_ref().unwrap();
+        let entry = self.entry.as_ref().unwrap();
         let mut map = self.group.map.lock();
-        if map
-            .get(&self.key)
-            .is_some_and(|existing| Arc::ptr_eq(cell, existing))
-        {
-            map.remove(&self.key);
-        }
+        map.remove_exact(entry);
     }
 
     fn disarm_cleanup(&mut self) {
-        drop(self.cell.take());
+        drop(self.entry.take());
     }
 }
 
@@ -91,34 +83,25 @@ where
     S: BuildHasher,
 {
     fn drop(&mut self) {
-        let Some(cell) = self.cell.take() else {
+        let Some(entry) = self.entry.take() else {
             return;
         };
-        if cell.get().is_some() {
+        if entry.cell().get().is_some() {
             return;
         }
 
         let mut map = self.group.map.lock();
-
-        // The map and each current call own one strong reference. If the map still points to this
-        // cell, a count of two means only the map and this last call own it. Drop this call's
-        // reference before unlocking so a waiting cleanup observes the updated count.
-        let should_remove = Arc::strong_count(&cell) == 2
-            && map
-                .get(&self.key)
-                .is_some_and(|existing| Arc::ptr_eq(&cell, existing) && existing.get().is_none());
-        if should_remove {
-            map.remove(&self.key);
-        }
-        drop(cell);
+        map.remove_abandoned(&entry);
+        // Let another cleanup waiting for the map observe the updated reference count.
+        drop(entry);
     }
 }
 
 impl<K, V, S> Default for Group<K, V, S>
 where
-    K: Eq + Hash + Clone,
+    K: Eq + Hash,
     V: Clone,
-    S: BuildHasher + Clone + Default,
+    S: BuildHasher + Default,
 {
     fn default() -> Self {
         Self::with_hasher(S::default())
@@ -127,27 +110,27 @@ where
 
 impl<K, V> Group<K, V, RandomState>
 where
-    K: Eq + Hash + Clone,
+    K: Eq + Hash,
     V: Clone,
 {
     /// Creates a new Group with the default hasher.
     pub fn new() -> Self {
         Self {
-            map: Mutex::new(HashMap::new()),
+            map: Mutex::new(KeyedOnceTable::with_hasher(RandomState::new())),
         }
     }
 }
 
 impl<K, V, S> Group<K, V, S>
 where
-    K: Eq + Hash + Clone,
+    K: Eq + Hash,
     V: Clone,
-    S: BuildHasher + Clone,
+    S: BuildHasher,
 {
     /// Creates a new Group with the given hasher.
     pub fn with_hasher(hasher: S) -> Self {
         Self {
-            map: Mutex::new(HashMap::with_hasher(hasher)),
+            map: Mutex::new(KeyedOnceTable::with_hasher(hasher)),
         }
     }
 

--- a/mea/src/singleflight/mod.rs
+++ b/mea/src/singleflight/mod.rs
@@ -34,6 +34,93 @@ pub struct Group<K, V, S = RandomState> {
     map: Mutex<HashMap<K, Arc<OnceCell<V>>, S>>,
 }
 
+// Holds one call's cell reference so Drop can clean up an abandoned entry.
+struct WorkCleanupGuard<'a, K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    group: &'a Group<K, V, S>,
+    key: K,
+    cell: Option<Arc<OnceCell<V>>>,
+}
+
+impl<'a, K, V, S> WorkCleanupGuard<'a, K, V, S>
+where
+    K: Eq + Hash + Clone,
+    S: BuildHasher,
+{
+    fn new(group: &'a Group<K, V, S>, key: K) -> Self {
+        let cell = {
+            let mut map = group.map.lock();
+            map.entry(key.clone())
+                .or_insert_with(|| Arc::new(OnceCell::new()))
+                .clone()
+        };
+
+        Self {
+            group,
+            key,
+            cell: Some(cell),
+        }
+    }
+
+    fn cell(&self) -> &OnceCell<V> {
+        self.cell.as_deref().unwrap()
+    }
+
+    fn remove_completed_entry(&self) {
+        let cell = self.cell.as_ref().unwrap();
+        let mut map = self.group.map.lock();
+        if map
+            .get(&self.key)
+            .is_some_and(|existing| Arc::ptr_eq(cell, existing))
+        {
+            map.remove(&self.key);
+        }
+    }
+
+    fn disarm_cleanup(&mut self) {
+        drop(self.cell.take());
+    }
+}
+
+impl<K, V, S> Drop for WorkCleanupGuard<'_, K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    fn drop(&mut self) {
+        let Some(cell) = self.cell.take() else {
+            return;
+        };
+        if cell.get().is_some() {
+            return;
+        }
+
+        let cell_ptr = Arc::as_ptr(&cell);
+        let mut map = self.group.map.lock();
+
+        // The map and each current call own one strong reference. With the map locked, a count of
+        // two means this may be the last call using the mapped cell. Other counts mean that another
+        // call can still retry the cell, or that `forget` has already removed it.
+        let may_be_last_call = Arc::strong_count(&cell) == 2;
+        drop(cell);
+        if !may_be_last_call {
+            return;
+        }
+
+        let should_remove = map.get(&self.key).is_some_and(|existing| {
+            cell_ptr == Arc::as_ptr(existing)
+                && Arc::strong_count(existing) == 1
+                && existing.get().is_none()
+        });
+        if should_remove {
+            map.remove(&self.key);
+        }
+    }
+}
+
 impl<K, V, S> Default for Group<K, V, S>
 where
     K: Eq + Hash + Clone,
@@ -76,6 +163,9 @@ where
     ///
     /// If a duplicate comes in, the duplicate caller waits for the original to complete and
     /// receives the same results.
+    ///
+    /// If the computation is cancelled or panics, another current caller may retry it. The empty
+    /// entry is removed once no current callers remain.
     ///
     /// Once the function completes, the key, if not [`forgotten`], is removed from the group,
     /// allowing future calls with the same key to execute the function again.
@@ -124,35 +214,18 @@ where
     where
         F: AsyncFnOnce() -> V,
     {
-        // 1. Get or create the OnceCell.
-        let cell = {
-            let mut map = self.map.lock();
-            map.entry(key.clone())
-                .or_insert_with(|| Arc::new(OnceCell::new()))
-                .clone()
-        };
-
-        // 2. Try to initialize the cell.
-        // OnceCell::get_or_init guarantees that only one task executes the closure.
-        let res = cell
+        let mut guard = WorkCleanupGuard::new(self, key);
+        let result = guard
+            .cell()
             .get_or_init(async || {
                 let result = func().await;
-
-                // Cleanup: remove the key from the map.
-                // We must ensure we remove the entry corresponding to *this* cell.
-                let mut map = self.map.lock();
-                if let Some(existing) = map.get(&key) {
-                    // Check if the map still points to our cell.
-                    if Arc::ptr_eq(&cell, existing) {
-                        map.remove(&key);
-                    }
-                }
-
+                guard.remove_completed_entry();
                 result
             })
-            .await;
-
-        res.clone()
+            .await
+            .clone();
+        guard.disarm_cleanup();
+        result
     }
 
     /// Executes and returns the results of the given function, making sure that only one execution
@@ -161,8 +234,8 @@ where
     /// If a duplicate comes in, the duplicate caller waits for the original to complete and
     /// receives the same results.
     ///
-    /// If the computation fails, the error is returned for the caller. Other tasks waiting for the
-    /// result will retry the computation.
+    /// If the computation fails, is cancelled or panics, other current callers may retry it. The
+    /// empty entry is removed once no current callers remain.
     ///
     /// Once the function completes successfully, the key, if not [`forgotten`], is removed from
     /// the group, allowing future calls with the same key to execute the function again.
@@ -205,35 +278,18 @@ where
     where
         F: AsyncFnOnce() -> Result<V, E>,
     {
-        // 1. Get or create the OnceCell.
-        let cell = {
-            let mut map = self.map.lock();
-            map.entry(key.clone())
-                .or_insert_with(|| Arc::new(OnceCell::new()))
-                .clone()
-        };
-
-        // 2. Try to initialize the cell.
-        // OnceCell::get_or_try_init guarantees that only one task executes the closure.
-        let res = cell
+        let mut guard = WorkCleanupGuard::new(self, key);
+        let result = guard
+            .cell()
             .get_or_try_init(async || {
                 let result = func().await?;
-
-                // Cleanup: remove the key from the map.
-                // We must ensure we remove the entry corresponding to *this* cell.
-                let mut map = self.map.lock();
-                if let Some(existing) = map.get(&key) {
-                    // Check if the map still points to our cell.
-                    if Arc::ptr_eq(&cell, existing) {
-                        map.remove(&key);
-                    }
-                }
-
+                guard.remove_completed_entry();
                 Ok(result)
             })
-            .await?;
-
-        Ok(res.clone())
+            .await?
+            .clone();
+        guard.disarm_cleanup();
+        Ok(result)
     }
 
     /// Forgets about the given key.

--- a/mea/src/singleflight/mod.rs
+++ b/mea/src/singleflight/mod.rs
@@ -20,9 +20,9 @@ use std::hash::Hash;
 use std::hash::RandomState;
 use std::sync::Arc;
 
-use crate::internal::KeyedOnceEntry;
-use crate::internal::KeyedOnceTable;
 use crate::internal::Mutex;
+use crate::internal::OnceTable;
+use crate::internal::OnceTableEntry;
 use crate::once::OnceCell;
 
 #[cfg(test)]
@@ -32,7 +32,7 @@ mod tests;
 /// units of work can be executed with duplicate suppression.
 #[derive(Debug)]
 pub struct Group<K, V, S = RandomState> {
-    map: Mutex<KeyedOnceTable<K, V, S>>,
+    map: Mutex<OnceTable<K, V, S>>,
 }
 
 // Holds one call's entry so Drop can clean it up if the work is abandoned.
@@ -42,7 +42,7 @@ where
     S: BuildHasher,
 {
     group: &'a Group<K, V, S>,
-    entry: Option<Arc<KeyedOnceEntry<K, V>>>,
+    entry: Option<Arc<OnceTableEntry<K, V>>>,
 }
 
 impl<'a, K, V, S> WorkCleanupGuard<'a, K, V, S>
@@ -53,7 +53,7 @@ where
     fn new(group: &'a Group<K, V, S>, key: K) -> Self {
         let entry = {
             let mut map = group.map.lock();
-            Arc::clone(map.get_or_insert(key))
+            Arc::clone(map.get_or_insert(key).get())
         };
 
         Self {
@@ -72,7 +72,7 @@ where
         map.remove_exact(entry);
     }
 
-    fn disarm_cleanup(&mut self) {
+    fn dismiss(mut self) {
         drop(self.entry.take());
     }
 }
@@ -86,7 +86,7 @@ where
         let Some(entry) = self.entry.take() else {
             return;
         };
-        if entry.cell().get().is_some() {
+        if entry.cell().initialized() {
             return;
         }
 
@@ -116,7 +116,7 @@ where
     /// Creates a new Group with the default hasher.
     pub fn new() -> Self {
         Self {
-            map: Mutex::new(KeyedOnceTable::with_hasher(RandomState::new())),
+            map: Mutex::new(OnceTable::with_hasher(RandomState::new())),
         }
     }
 }
@@ -130,7 +130,7 @@ where
     /// Creates a new Group with the given hasher.
     pub fn with_hasher(hasher: S) -> Self {
         Self {
-            map: Mutex::new(KeyedOnceTable::with_hasher(hasher)),
+            map: Mutex::new(OnceTable::with_hasher(hasher)),
         }
     }
 
@@ -190,7 +190,7 @@ where
     where
         F: AsyncFnOnce() -> V,
     {
-        let mut guard = WorkCleanupGuard::new(self, key);
+        let guard = WorkCleanupGuard::new(self, key);
         let result = guard
             .cell()
             .get_or_init(async || {
@@ -200,7 +200,7 @@ where
             })
             .await
             .clone();
-        guard.disarm_cleanup();
+        guard.dismiss();
         result
     }
 
@@ -254,7 +254,7 @@ where
     where
         F: AsyncFnOnce() -> Result<V, E>,
     {
-        let mut guard = WorkCleanupGuard::new(self, key);
+        let guard = WorkCleanupGuard::new(self, key);
         let result = guard
             .cell()
             .get_or_try_init(async || {
@@ -264,7 +264,7 @@ where
             })
             .await?
             .clone();
-        guard.disarm_cleanup();
+        guard.dismiss();
         Ok(result)
     }
 

--- a/mea/src/singleflight/tests.rs
+++ b/mea/src/singleflight/tests.rs
@@ -12,21 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
-use std::task::Context;
-use std::task::Poll;
-use std::task::Waker;
 use std::time::Duration;
 
+use crate::poll_once;
 use crate::singleflight::Group;
-
-fn poll_once<F: Future>(future: Pin<&mut F>) -> Poll<F::Output> {
-    future.poll(&mut Context::from_waker(Waker::noop()))
-}
 
 #[tokio::test]
 async fn test_simple() {

--- a/mea/src/singleflight/tests.rs
+++ b/mea/src/singleflight/tests.rs
@@ -12,12 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
+use std::task::Context;
+use std::task::Poll;
+use std::task::Waker;
 use std::time::Duration;
 
 use crate::singleflight::Group;
+
+fn poll_once<F: Future>(future: Pin<&mut F>) -> Poll<F::Output> {
+    future.poll(&mut Context::from_waker(Waker::noop()))
+}
 
 #[tokio::test]
 async fn test_simple() {
@@ -137,10 +146,34 @@ async fn test_panic_safe() {
     // Wait for h1 to panic and exit
     let err = h1.await.unwrap_err();
     assert!(err.is_panic());
+    assert!(group.map.lock().is_empty());
 
     // Next task should succeed (new attempt)
     let res = group.work("key", || async { "success".to_string() }).await;
     assert_eq!(res, "success");
+}
+
+#[tokio::test]
+async fn test_cancelled_work_removes_empty_entry() {
+    let group = Arc::new(Group::<&str, &str>::new());
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+    let group_clone = group.clone();
+    let task = tokio::spawn(async move {
+        group_clone
+            .work("key", || async move {
+                started_tx.send(()).unwrap();
+                std::future::pending().await
+            })
+            .await
+    });
+
+    started_rx.await.unwrap();
+    assert_eq!(group.map.lock().len(), 1);
+
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
+    assert!(group.map.lock().is_empty());
 }
 
 #[tokio::test]
@@ -192,6 +225,7 @@ async fn test_try_work_failure() {
         .try_work("key", || async { Err::<&str, &str>("error") })
         .await;
     assert_eq!(res, Err("error"));
+    assert!(group.map.lock().is_empty());
 
     // Retry should work
     let res2 = group
@@ -202,33 +236,25 @@ async fn test_try_work_failure() {
 
 #[tokio::test]
 async fn test_try_work_wait_and_retry() {
-    let group = Arc::new(Group::new());
-    let counter = Arc::new(AtomicUsize::new(0));
+    let group = Group::new();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
 
-    let g1 = group.clone();
-    let c1 = counter.clone();
-    let h1 = tokio::spawn(async move {
-        g1.try_work("key", || async move {
-            c1.fetch_add(1, Ordering::SeqCst);
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            Err::<&str, &str>("fail")
-        })
-        .await
+    let first = group.try_work("key", || async move {
+        release_rx.await.unwrap();
+        Err::<&str, &str>("fail")
     });
+    tokio::pin!(first);
+    assert!(poll_once(first.as_mut()).is_pending());
 
-    let g2 = group.clone();
-    let c2 = counter.clone();
-    let h2 = tokio::spawn(async move {
-        // Ensure h1 starts first
-        tokio::time::sleep(Duration::from_millis(10)).await;
-        g2.try_work("key", || async move {
-            c2.fetch_add(1, Ordering::SeqCst);
-            Ok::<&str, ()>("success")
-        })
-        .await
-    });
+    let retry = group.try_work("key", || async { Ok::<&str, &str>("success") });
+    tokio::pin!(retry);
+    assert!(poll_once(retry.as_mut()).is_pending());
 
-    assert_eq!(h1.await.unwrap(), Err("fail"));
-    assert_eq!(h2.await.unwrap(), Ok("success"));
-    assert_eq!(counter.load(Ordering::SeqCst), 2);
+    release_tx.send(()).unwrap();
+    assert_eq!(first.await, Err("fail"));
+
+    // The failed caller must not remove the cell while an existing waiter can still retry it.
+    assert_eq!(group.map.lock().len(), 1);
+    assert_eq!(retry.await, Ok("success"));
+    assert!(group.map.lock().is_empty());
 }

--- a/mea/src/singleflight/tests.rs
+++ b/mea/src/singleflight/tests.rs
@@ -28,6 +28,16 @@ async fn test_simple() {
 }
 
 #[tokio::test]
+async fn test_non_clone_key() {
+    #[derive(Hash, PartialEq, Eq)]
+    struct Key(&'static str);
+
+    let group = Group::new();
+    let res = group.work(Key("key"), || async { "val" }).await;
+    assert_eq!(res, "val");
+}
+
+#[tokio::test]
 async fn test_coalescing() {
     let group = Arc::new(Group::new());
     let counter = Arc::new(AtomicUsize::new(0));
@@ -94,7 +104,7 @@ async fn test_forget() {
     let g1 = group.clone();
     let c1 = counter.clone();
     let h1 = tokio::spawn(async move {
-        g1.work("key", || async move {
+        g1.work("key".to_owned(), || async move {
             tokio::time::sleep(Duration::from_millis(100)).await;
             c1.fetch_add(1, Ordering::SeqCst);
             "val1"
@@ -104,12 +114,12 @@ async fn test_forget() {
 
     // Wait a bit to ensure the first call is established
     tokio::time::sleep(Duration::from_millis(10)).await;
-    group.forget(&"key");
+    group.forget("key");
 
     let g2 = group.clone();
     let c2 = counter.clone();
     let h2 = tokio::spawn(async move {
-        g2.work("key", || async move {
+        g2.work("key".to_owned(), || async move {
             tokio::time::sleep(Duration::from_millis(100)).await;
             c2.fetch_add(1, Ordering::SeqCst);
             "val2"


### PR DESCRIPTION
## Summary

- remove uninitialized `OnceMap` and `singleflight::Group` entries after the last active call fails, panics, or is cancelled
- preserve a shared entry while another caller can still retry the same in-flight computation
- use `hashbrown::HashTable` to make exact abandoned-entry cleanup expected O(1), without an active-call counter or an extra atomic RMW on every call
- retain borrowed-key lookup and avoid adding `Clone` bounds to keys and custom hashers
- keep hash-table handles and `OnceCell` access behind the internal `OnceTable` and `OnceTableEntry` APIs
- cover cached, successful, failed, cancelled, panicking, and retrying keyed-once operations with tests and Divan benchmarks
- align the crate-visible `OnceCell::initialized_mut` query with `initialized`

## Design

This revisits #133 with one ownership invariant:

- the table owns one strong `Arc<OnceTableEntry<K, V>>`
- each active call owns one strong reference through its cleanup guard

The entry stores its precomputed hash, key, and `OnceCell`. Moving the key into the shared entry lets a call retain entry identity without cloning `K`. When an unsuccessful call exits, its guard locks the table while retaining its `Arc`. If the entry is still uninitialized and the strong count is two, the table and the current call are its only owners. The table then removes that exact allocation using its cached hash and `Arc::ptr_eq`.

Allocation identity is required because `forget`, `discard`, or `remove` can detach an old entry and a later call can insert a replacement for the same key. A stale guard must not remove the replacement.

`HashTable` is used instead of `HashMap::retain` or `HashMap::raw_entry_mut`:

- `retain` scans every entry and made failed cleanup O(n)
- a raw `HashMap` lookup can match only on the key, while exact cleanup must match the entry allocation after the guard has transferred ownership of `K`
- `HashTable` can hash into the relevant bucket and compare the complete entry, giving expected O(1) exact removal

The hash-table details stay in one private `OnceTable`. Its lookup and insertion methods return logical entries rather than exposing `hashbrown` entry handles. `OnceTableEntry` owns value inspection and initialization, so `OnceMap` and `Group` do not reach through it to the underlying `OnceCell`. Cleanup guards keep the lifecycle rule—the last caller removes an uninitialized entry—at the call site. `Group` removes a completed entry inside the initializer before `OnceCell` publishes the result. The cached `OnceMap` path clones the value directly while holding the table lock, so it does not add an `Arc` RMW.

`hashbrown` 0.17.1 has the same Rust 1.85 MSRV as mea. Default features are disabled and only `inline-more` is enabled, so this adds no transitive normal dependency.

## Benchmarks

These are Divan medians from an arm64 Linux OrbStack VM using Rust 1.85.1, comparing the previous O(n) implementation at `5899bbf` with this update. The successful paths are unchanged in behavior; the failure rows include cleanup.

| Case | O(n) cleanup | `HashTable` cleanup | Change |
| --- | ---: | ---: | ---: |
| OnceMap cached | 21.06 ns | 20.77 ns | -1% |
| OnceMap vacant success | 56.7 ns | 57.39 ns | +1% |
| OnceMap error, 0 entries | 65.51 ns | 65.2 ns | unchanged |
| OnceMap error, 64 entries | 205.4 ns | 70.08 ns | -66% |
| OnceMap error, 1024 entries | 2.187 µs | 84.4 ns | -96% |
| Group success | 86.32 ns | 69.43 ns | -20% |
| Group error | 79.82 ns | 66.83 ns | -16% |

The cached and vacant `OnceMap` paths remain within measurement noise. Failed cleanup no longer scales linearly with the number of cached entries. macOS measurements show the same shape, including a reduction from about 2.10 µs to 208 ns for the 1024-entry failure case. A focused before/after run for the final structural simplification measured the extended vacant-success case at the same 114.2 ns median on both revisions.

## Verification

- `cargo x lint`
- `cargo test --workspace --all-features`
- `cargo +1.85.0 check --workspace --all-targets`
- `cargo +1.85.0 test --workspace --no-default-features`
- `cargo x semver --release-version 0.6.6`
- `cargo bench --bench primitives -- --test`
