### PR TITLE
fix: preserve semaphore state on overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 * Make cloning a `WaitGroup` panic on counter overflow instead of silently losing track of a handle.
 * Align `Condvar` with standard condition-variable semantics by notifying only current waiters and passing a cancelled `notify_one` wakeup to another current waiter instead of storing a permit.
 * Clean up uninitialized `OnceMap` and `singleflight` entries once no callers remain after a failure, panic, or cancellation.
+* Preserve semaphore permits when releasing permits panics on overflow.
 
 ### Improvements
 

--- a/mea/benches/primitives/semaphore.rs
+++ b/mea/benches/primitives/semaphore.rs
@@ -12,12 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod once_map;
-mod oneshot;
-mod semaphore;
-mod singleflight;
-mod support;
+use divan::Bencher;
+use divan::black_box;
+use mea::semaphore::Semaphore;
 
-fn main() {
-    divan::main();
+#[divan::bench]
+fn release(bencher: Bencher) {
+    bencher
+        .with_inputs(|| Semaphore::new(0))
+        .bench_local_values(|semaphore| {
+            semaphore.release(black_box(1));
+            black_box(semaphore)
+        });
+}
+
+#[divan::bench]
+fn try_acquire_release(bencher: Bencher) {
+    let semaphore = Semaphore::new(1);
+
+    bencher.bench_local(|| {
+        drop(black_box(semaphore.try_acquire(black_box(1)).unwrap()));
+    });
 }

--- a/mea/src/internal/semaphore.rs
+++ b/mea/src/internal/semaphore.rs
@@ -162,26 +162,6 @@ impl Semaphore {
         }
     }
 
-    fn add_available_permits(&self, permits: usize) {
-        let mut current = self.permits.load(Ordering::Relaxed);
-        loop {
-            let next = current.checked_add(permits).unwrap_or_else(|| {
-                panic!(
-                    "number of added permits ({permits}) would overflow usize::MAX (prev: {current})"
-                )
-            });
-            match self.permits.compare_exchange_weak(
-                current,
-                next,
-                Ordering::Release,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => return,
-                Err(actual) => current = actual,
-            }
-        }
-    }
-
     fn insert_permits_with_lock(
         &self,
         mut rem: usize,
@@ -215,7 +195,14 @@ impl Semaphore {
             }
 
             if rem > 0 && waiters.is_empty() {
-                self.add_available_permits(rem);
+                // Holding `waiters` serializes all permit additions. Concurrent operations can
+                // only remove permits, so the count cannot grow between this check and fetch_add.
+                let current = self.permits.load(Ordering::Relaxed);
+                assert!(
+                    current.checked_add(rem).is_some(),
+                    "number of added permits ({rem}) would overflow usize::MAX (prev: {current})"
+                );
+                self.permits.fetch_add(rem, Ordering::Release);
                 rem = 0;
             }
 

--- a/mea/src/internal/semaphore.rs
+++ b/mea/src/internal/semaphore.rs
@@ -162,6 +162,26 @@ impl Semaphore {
         }
     }
 
+    fn add_available_permits(&self, permits: usize) {
+        let mut current = self.permits.load(Ordering::Relaxed);
+        loop {
+            let next = current.checked_add(permits).unwrap_or_else(|| {
+                panic!(
+                    "number of added permits ({permits}) would overflow usize::MAX (prev: {current})"
+                )
+            });
+            match self.permits.compare_exchange_weak(
+                current,
+                next,
+                Ordering::Release,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return,
+                Err(actual) => current = actual,
+            }
+        }
+    }
+
     fn insert_permits_with_lock(
         &self,
         mut rem: usize,
@@ -195,12 +215,7 @@ impl Semaphore {
             }
 
             if rem > 0 && waiters.is_empty() {
-                let permits = rem;
-                let prev = self.permits.fetch_add(permits, Ordering::Release);
-                assert!(
-                    prev.checked_add(permits).is_some(),
-                    "number of added permits ({permits}) would overflow usize::MAX (prev: {prev})"
-                );
+                self.add_available_permits(rem);
                 rem = 0;
             }
 

--- a/mea/src/semaphore/tests.rs
+++ b/mea/src/semaphore/tests.rs
@@ -108,18 +108,17 @@ fn add_max_amount_permits() {
 }
 
 #[test]
-#[should_panic]
-fn add_more_than_max_amount_permits1() {
-    let s = Semaphore::new(1);
-    s.release(usize::MAX);
-}
+fn release_overflow_preserves_permits() {
+    let s = Semaphore::new(usize::MAX);
+    let result = std::panic::catch_unwind(|| s.release(1));
 
-#[test]
-#[should_panic]
-fn add_more_than_max_amount_permits2() {
-    let s = Semaphore::new(usize::MAX - 1);
-    s.release(1);
-    s.release(1);
+    assert!(result.is_err());
+    assert_eq!(s.available_permits(), usize::MAX);
+
+    let permit = s.try_acquire(1).unwrap();
+    assert_eq!(s.available_permits(), usize::MAX - 1);
+    drop(permit);
+    assert_eq!(s.available_permits(), usize::MAX);
 }
 
 #[test]

--- a/mea/src/semaphore/tests.rs
+++ b/mea/src/semaphore/tests.rs
@@ -108,6 +108,12 @@ fn add_max_amount_permits() {
 }
 
 #[test]
+#[should_panic(expected = "would overflow usize::MAX")]
+fn release_overflow_panics() {
+    Semaphore::new(usize::MAX).release(1);
+}
+
+#[test]
 fn release_overflow_preserves_permits() {
     let s = Semaphore::new(usize::MAX);
     let result = std::panic::catch_unwind(|| s.release(1));


### PR DESCRIPTION
## Summary

- check semaphore permit overflow before changing the counter
- keep the existing `fetch_add` release path instead of adding a CAS retry loop
- add Divan benchmarks for `release` and the common acquire/release round trip
- cover both the public panic contract and post-panic semaphore usability

## Problem

The previous implementation used `fetch_add` and checked its returned value afterward. Atomic integer addition wraps, so an overflowing `Semaphore::release` had already written the wrapped permit count before the assertion panicked. For example, releasing one permit at `usize::MAX` left the semaphore with zero available permits.

## Implementation

Every path that adds available permits already holds the `waiters` lock. While that lock is held, concurrent lock-free operations can only remove permits. The implementation therefore loads and checks the current count under the lock, then uses the existing `fetch_add`; the count cannot grow between those two operations, so a successful check guarantees the addition cannot overflow.

The checked load is `Relaxed` because it is used only for the numeric overflow decision. The `fetch_add` remains `Release`, preserving the synchronization behavior of the original implementation.

This avoids both failure modes considered during the change: checking after `fetch_add` temporarily corrupts observable state, while a CAS loop adds unnecessary work and complexity to every successful release.

## Tests

- `release_overflow_panics` is an independent `#[should_panic]` test for the documented API contract
- `release_overflow_preserves_permits` catches the panic, verifies the count remains `usize::MAX`, and confirms the semaphore is still usable
- `cargo x lint`
- `cargo x test`
- `cargo x bench`
- `cargo +1.85.0 test --workspace --no-default-features`
- `cargo +1.85.0 bench -p mea --bench primitives --no-run`

## Benchmarks

The same benchmark source was applied to `main` and this branch. Fixed-size Divan runs used 500 samples of 100,000 iterations to avoid timer-resolution artifacts.

- Linux/aarch64, two paired runs: `release` was +0.8% and +2.2%; `try_acquire_release` was -1.2% and +1.4%
- macOS/aarch64: `release` was +2.7%; `try_acquire_release` was +1.3%

The Linux results are within run-to-run variation, while macOS shows the small cost of the additional read and overflow check rather than the larger cost of a CAS retry loop.
