### PR TITLE
docs: complete post-v0.6.5 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,17 @@ All notable changes to this project will be documented in this file.
 
 * Prevent `OwnedMappedMutexGuard` from allowing invalid lifetime coercions. ([#121](https://github.com/fast/mea/pull/121))
 * Require the protected value of an `OwnedRwLockReadGuard` to be both `Send` and `Sync` before the guard can be sent across threads. ([#122](https://github.com/fast/mea/pull/122))
-* Wake waiting tasks only after releasing internal locks. ([#125](https://github.com/fast/mea/pull/125))
+* Prevent reentrant wakers from deadlocking or poisoning `Barrier`, `Latch`, `WaitGroup`, `Once`, and `broadcast::overflow` operations. ([#125](https://github.com/fast/mea/pull/125))
 * Retry spurious atomic failures when completing `Once` initialization. ([#126](https://github.com/fast/mea/pull/126))
-* Make cloning a `WaitGroup` panic on counter overflow instead of silently losing track of a handle.
-* Align `Condvar` with standard condition-variable semantics by notifying only current waiters and passing a cancelled `notify_one` wakeup to another current waiter instead of storing a permit.
-* Clean up uninitialized `OnceMap` and `singleflight` entries once no callers remain after a failure, panic, or cancellation.
-* Preserve semaphore permits when releasing permits panics on overflow.
+* Make cloning a `WaitGroup` panic on counter overflow instead of silently losing track of a handle. ([#128](https://github.com/fast/mea/pull/128))
+* Align `Condvar` with standard non-buffered notification semantics by notifying only current waiters and passing a cancelled `notify_one` wakeup to another current waiter. ([#132](https://github.com/fast/mea/pull/132))
+* Ensure polling or cancelling a contended `oneshot` receive does not wait for the sender to make progress. ([#138](https://github.com/fast/mea/pull/138))
+* Clean up uninitialized `OnceMap` and `singleflight::Group` entries once no callers remain after a failure, panic, or cancellation. ([#142](https://github.com/fast/mea/pull/142))
+* Keep a semaphore's permit count unchanged when `Semaphore::release` panics on overflow. ([#144](https://github.com/fast/mea/pull/144))
 
 ### Improvements
 
-* Remove unnecessary `Clone` bounds from `singleflight` keys and custom hashers used by keyed once primitives.
+* Remove unnecessary `Clone` bounds from `singleflight::Group` keys and custom hashers used by `OnceMap` and `singleflight::Group`. ([#142](https://github.com/fast/mea/pull/142))
 
 ## v0.6.5 (2026-07-30)
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ All synchronization primitives in this library are runtime-agnostic, meaning the
 
 ## Thread Safety
 
-All types in this library implement `Send` and `Sync`, making them safe to share across thread boundaries. This is essential for concurrent programming where data needs to be accessed from multiple threads.
+MEA primitives and guards implement `Send` and `Sync` only when the protected or transferred value satisfies the necessary bounds. In particular, owned read guards that may move destruction to another thread require the protected value to be `Send` as well as `Sync`. See each type's documentation for its exact bounds.
 
 ## Minimum Supported Rust Version (MSRV)
 

--- a/mea/src/lib.rs
+++ b/mea/src/lib.rs
@@ -53,9 +53,10 @@
 //!
 //! # Thread Safety
 //!
-//! All primitive types in this library implement `Send` and `Sync`, making them safe to share
-//! across thread boundaries. This is essential for concurrent programming where data needs to be
-//! accessed from multiple threads.
+//! MEA primitives and guards implement `Send` and `Sync` only when the protected or transferred
+//! value satisfies the necessary bounds. In particular, owned read guards that may move
+//! destruction to another thread require the protected value to be `Send` as well as `Sync`. See
+//! each type's documentation for its exact bounds.
 //!
 //! [`Barrier`]: barrier::Barrier
 //! [`Condvar`]: condvar::Condvar


### PR DESCRIPTION
## Summary

- audit user-visible changes between `v0.6.5` and current `main` (`263582e`)
- add the missing `oneshot` progress fix to the Unreleased changelog and link the remaining entries to their source PRs
- describe the wake-outside-lock fix in terms of the affected public primitives
- correct the README and crate-level thread-safety claim so it reflects conditional `Send` and `Sync` bounds

## Audit scope

The audit covered every commit plus the source and regression-test diff in `v0.6.5..263582e`. CI, benchmark scaffolding, internal refactors, and documentation-only clarification of existing `Barrier` cancellation behavior are intentionally excluded from the changelog because they do not change end-user behavior. The Unreleased heading is retained for the release workflow.

## Validation

- `cargo x lint`
- `cargo x test`
- `cargo x semver --release-version 0.6.6`
- `git diff --check`