### PR TITLE
docs: announce upcoming Asyncband rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # MEA (Modular Essentials for Async)
 
+> [!IMPORTANT]
+> This crate will be renamed to [`asyncband`](https://crates.io/crates/asyncband). Future development and releases will continue under the new name, with documentation at [docs.rs/asyncband](https://docs.rs/asyncband).
+
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
 [![MSRV 1.85][msrv-badge]](https://www.whatrustisit.com)

--- a/mea/src/lib.rs
+++ b/mea/src/lib.rs
@@ -15,6 +15,11 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_docs)]
 
+//! > **Upcoming rename:** This crate will be renamed to
+//! > [`asyncband`](https://crates.io/crates/asyncband). Future development and releases will
+//! > continue under the new name, with documentation at
+//! > [docs.rs/asyncband](https://docs.rs/asyncband).
+//!
 //! `mea` is a runtime-agnostic library providing essential synchronization primitives for
 //! asynchronous Rust programming. The library offers a collection of well-tested, efficient
 //! synchronization tools that work with any async runtime.


### PR DESCRIPTION
## Summary

- announce the upcoming rename from `mea` to `asyncband` prominently in the README
- surface the same notice on the docs.rs crate landing page
- link to the future crates.io package and docs.rs documentation while leaving the current crate unchanged

## Sequencing

This PR is intended to land before #149, which performs the actual rebrand.

## Validation

- `cargo doc --package mea --all-features --no-deps`
- `cargo x lint`